### PR TITLE
Avoid unnecessary memory operations when setting Bullet affine.

### DIFF
--- a/scs2-bullet-simulation/src/main/java/us/ihmc/scs2/simulation/bullet/physicsEngine/BulletTools.java
+++ b/scs2-bullet-simulation/src/main/java/us/ihmc/scs2/simulation/bullet/physicsEngine/BulletTools.java
@@ -12,6 +12,7 @@ import org.bytedeco.bullet.BulletCollision.btCylinderShapeZ;
 import org.bytedeco.bullet.BulletCollision.btGImpactMeshShape;
 import org.bytedeco.bullet.BulletCollision.btSphereShape;
 import org.bytedeco.bullet.BulletCollision.btTriangleMesh;
+import org.bytedeco.bullet.LinearMath.btMatrix3x3;
 import org.bytedeco.bullet.LinearMath.btQuaternion;
 import org.bytedeco.bullet.LinearMath.btTransform;
 import org.bytedeco.bullet.LinearMath.btVector3;
@@ -31,20 +32,25 @@ import us.ihmc.scs2.definition.geometry.*;
 
 public class BulletTools
 {
+   private static final btVector3 origin = new btVector3();
+   private static final btMatrix3x3 basis = new btMatrix3x3();
+
    public static void toBullet(RigidBodyTransform rigidBodyTransform, btTransform bulletAffineToPack)
    {
-      bulletAffineToPack.getOrigin().setValue(rigidBodyTransform.getTranslationX(),
-                                              rigidBodyTransform.getTranslationY(),
-                                              rigidBodyTransform.getTranslationZ());
-      bulletAffineToPack.getBasis().setValue(rigidBodyTransform.getM00(),
-                                             rigidBodyTransform.getM01(),
-                                             rigidBodyTransform.getM02(),
-                                             rigidBodyTransform.getM10(),
-                                             rigidBodyTransform.getM11(),
-                                             rigidBodyTransform.getM12(),
-                                             rigidBodyTransform.getM20(),
-                                             rigidBodyTransform.getM21(),
-                                             rigidBodyTransform.getM22());
+      origin.setValue(rigidBodyTransform.getTranslationX(),
+                      rigidBodyTransform.getTranslationY(),
+                      rigidBodyTransform.getTranslationZ());
+      bulletAffineToPack.setOrigin(origin);
+      basis.setValue(rigidBodyTransform.getM00(),
+                     rigidBodyTransform.getM01(),
+                     rigidBodyTransform.getM02(),
+                     rigidBodyTransform.getM10(),
+                     rigidBodyTransform.getM11(),
+                     rigidBodyTransform.getM12(),
+                     rigidBodyTransform.getM20(),
+                     rigidBodyTransform.getM21(),
+                     rigidBodyTransform.getM22());
+      bulletAffineToPack.setBasis(basis);
    }
 
    public static void toEuclid(btTransform bulletAffine, RigidBodyTransform rigidBodyTransform)


### PR DESCRIPTION
From profiling I found that this was causing a bunch of unnecessary allocation. The performance doesn't seem to be much different, though.

Before:
![20231222_102011_Screenshot](https://github.com/ihmcrobotics/simulation-construction-set-2/assets/1161586/f9cbf353-545c-4e44-a42f-36b6f9750f13)
After:
![20231222_101902_Screenshot](https://github.com/ihmcrobotics/simulation-construction-set-2/assets/1161586/8bc51499-1e45-47ec-a812-fd89d1eaba74)



![image](https://github.com/ihmcrobotics/simulation-construction-set-2/assets/1161586/f0b3b64c-e842-44f4-b2df-f9fb32550bfa)
