### PR TITLE
Feature/undefined reference frames

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/camera/LevelOrbitalCoordinateProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/camera/LevelOrbitalCoordinateProperty.java
@@ -1,15 +1,15 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.camera;
 
-import static us.ihmc.scs2.definition.camera.YoLevelOrbitalCoordinateDefinition.YoLevelOrbital;
-import static us.ihmc.scs2.definition.camera.YoLevelOrbitalCoordinateDefinition.YoLevelOrbitalIdentifiers;
-
-import java.util.Objects;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.CompositeProperty;
+
+import java.util.Objects;
+
+import static us.ihmc.scs2.definition.camera.YoLevelOrbitalCoordinateDefinition.YoLevelOrbital;
+import static us.ihmc.scs2.definition.camera.YoLevelOrbitalCoordinateDefinition.YoLevelOrbitalIdentifiers;
 
 public class LevelOrbitalCoordinateProperty extends CompositeProperty
 {
@@ -23,7 +23,7 @@ public class LevelOrbitalCoordinateProperty extends CompositeProperty
       super(YoLevelOrbital, YoLevelOrbitalIdentifiers, distance, longitude, height);
    }
 
-   public LevelOrbitalCoordinateProperty(ReferenceFrame referenceFrame, double distance, double longitude, double height)
+   public LevelOrbitalCoordinateProperty(ReferenceFrameWrapper referenceFrame, double distance, double longitude, double height)
    {
       super(YoLevelOrbital, YoLevelOrbitalIdentifiers, referenceFrame, distance, longitude, height);
    }
@@ -33,7 +33,7 @@ public class LevelOrbitalCoordinateProperty extends CompositeProperty
       super(YoLevelOrbital, YoLevelOrbitalIdentifiers, distanceLongitudeHeightProperties);
    }
 
-   public LevelOrbitalCoordinateProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty[] distanceLongitudeHeightProperties)
+   public LevelOrbitalCoordinateProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty[] distanceLongitudeHeightProperties)
    {
       super(YoLevelOrbital, YoLevelOrbitalIdentifiers, referenceFrameProperty, distanceLongitudeHeightProperties);
    }
@@ -43,10 +43,10 @@ public class LevelOrbitalCoordinateProperty extends CompositeProperty
       super(YoLevelOrbital, YoLevelOrbitalIdentifiers, distanceProperty, longitudeProperty, heightProperty);
    }
 
-   public LevelOrbitalCoordinateProperty(Property<ReferenceFrame> referenceFrameProperty,
-                                               DoubleProperty distanceProperty,
-                                               DoubleProperty longitudeProperty,
-                                               DoubleProperty heightProperty)
+   public LevelOrbitalCoordinateProperty(Property<ReferenceFrameWrapper> referenceFrameProperty,
+                                         DoubleProperty distanceProperty,
+                                         DoubleProperty longitudeProperty,
+                                         DoubleProperty heightProperty)
    {
       super(YoLevelOrbital, YoLevelOrbitalIdentifiers, referenceFrameProperty, distanceProperty, longitudeProperty, heightProperty);
    }
@@ -92,9 +92,10 @@ public class LevelOrbitalCoordinateProperty extends CompositeProperty
       setComponentValues(distance, longitude, height);
    }
 
-   public void set(ReferenceFrame referenceFrame, double distance, double longitude, double height)
+   public void set(ReferenceFrameWrapper referenceFrame, double distance, double longitude, double height)
    {
-      set(referenceFrame, distance, longitude, height);
+      setReferenceFrame(referenceFrame);
+      setComponentValues(distance, longitude, height);
    }
 
    public void set(DoubleProperty distanceProperty, DoubleProperty longitudeProperty, DoubleProperty heightProperty)
@@ -102,12 +103,13 @@ public class LevelOrbitalCoordinateProperty extends CompositeProperty
       setComponentValueProperties(distanceProperty, longitudeProperty, heightProperty);
    }
 
-   public void set(Property<ReferenceFrame> referenceFrameProperty,
+   public void set(Property<ReferenceFrameWrapper> referenceFrameProperty,
                    DoubleProperty distanceProperty,
                    DoubleProperty longitudeProperty,
                    DoubleProperty heightProperty)
    {
-      set(referenceFrameProperty, distanceProperty, longitudeProperty, heightProperty);
+      setReferenceFrameProperty(referenceFrameProperty);
+      setComponentValueProperties(distanceProperty, longitudeProperty, heightProperty);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/camera/OrbitalCoordinateProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/camera/OrbitalCoordinateProperty.java
@@ -1,15 +1,15 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.camera;
 
-import static us.ihmc.scs2.definition.camera.YoOrbitalCoordinateDefinition.YoOrbital;
-import static us.ihmc.scs2.definition.camera.YoOrbitalCoordinateDefinition.YoOrbitalIdentifiers;
-
-import java.util.Objects;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.CompositeProperty;
+
+import java.util.Objects;
+
+import static us.ihmc.scs2.definition.camera.YoOrbitalCoordinateDefinition.YoOrbital;
+import static us.ihmc.scs2.definition.camera.YoOrbitalCoordinateDefinition.YoOrbitalIdentifiers;
 
 public class OrbitalCoordinateProperty extends CompositeProperty
 {
@@ -23,7 +23,7 @@ public class OrbitalCoordinateProperty extends CompositeProperty
       super(YoOrbital, YoOrbitalIdentifiers, distance, longitude, latitude);
    }
 
-   public OrbitalCoordinateProperty(ReferenceFrame referenceFrame, double distance, double longitude, double latitude)
+   public OrbitalCoordinateProperty(ReferenceFrameWrapper referenceFrame, double distance, double longitude, double latitude)
    {
       super(YoOrbital, YoOrbitalIdentifiers, referenceFrame, distance, longitude, latitude);
    }
@@ -33,7 +33,7 @@ public class OrbitalCoordinateProperty extends CompositeProperty
       super(YoOrbital, YoOrbitalIdentifiers, distanceLongitudeLatitudeProperties);
    }
 
-   public OrbitalCoordinateProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty[] distanceLongitudeLatitudeProperties)
+   public OrbitalCoordinateProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty[] distanceLongitudeLatitudeProperties)
    {
       super(YoOrbital, YoOrbitalIdentifiers, referenceFrameProperty, distanceLongitudeLatitudeProperties);
    }
@@ -43,10 +43,10 @@ public class OrbitalCoordinateProperty extends CompositeProperty
       super(YoOrbital, YoOrbitalIdentifiers, distanceProperty, longitudeProperty, latitudeProperty);
    }
 
-   public OrbitalCoordinateProperty(Property<ReferenceFrame> referenceFrameProperty,
-                                          DoubleProperty distanceProperty,
-                                          DoubleProperty longitudeProperty,
-                                          DoubleProperty latitudeProperty)
+   public OrbitalCoordinateProperty(Property<ReferenceFrameWrapper> referenceFrameProperty,
+                                    DoubleProperty distanceProperty,
+                                    DoubleProperty longitudeProperty,
+                                    DoubleProperty latitudeProperty)
    {
       super(YoOrbital, YoOrbitalIdentifiers, referenceFrameProperty, distanceProperty, longitudeProperty, latitudeProperty);
    }
@@ -92,9 +92,10 @@ public class OrbitalCoordinateProperty extends CompositeProperty
       setComponentValues(distance, longitude, latitude);
    }
 
-   public void set(ReferenceFrame referenceFrame, double distance, double longitude, double latitude)
+   public void set(ReferenceFrameWrapper referenceFrame, double distance, double longitude, double latitude)
    {
-      set(referenceFrame, distance, longitude, latitude);
+      setReferenceFrame(referenceFrame);
+      setComponentValues(distance, longitude, latitude);
    }
 
    public void set(DoubleProperty distanceProperty, DoubleProperty longitudeProperty, DoubleProperty latitudeProperty)
@@ -102,12 +103,13 @@ public class OrbitalCoordinateProperty extends CompositeProperty
       setComponentValueProperties(distanceProperty, longitudeProperty, latitudeProperty);
    }
 
-   public void set(Property<ReferenceFrame> referenceFrameProperty,
+   public void set(Property<ReferenceFrameWrapper> referenceFrameProperty,
                    DoubleProperty distanceProperty,
                    DoubleProperty longitudeProperty,
                    DoubleProperty latitudeProperty)
    {
-      set(referenceFrameProperty, distanceProperty, longitudeProperty, latitudeProperty);
+      setReferenceFrameProperty(referenceFrameProperty);
+      setComponentValueProperties(distanceProperty, longitudeProperty, latitudeProperty);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/YoCompositeEditorPaneController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/YoCompositeEditorPaneController.java
@@ -1,11 +1,6 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor;
 
-import java.util.Arrays;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-
 import com.jfoenix.controls.JFXTextField;
-
 import javafx.beans.binding.BooleanExpression;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -31,6 +26,7 @@ import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField.Ref
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField.YoCompositeSearchField;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic.YoGraphicFXControllerTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SessionVisualizerToolkit;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.YoCompositeSearchManager;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.CompositePropertyTools;
@@ -39,6 +35,10 @@ import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YoComposite;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YoCompositeCollection;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YoCompositePattern;
 import us.ihmc.scs2.sharedMemory.LinkedYoRegistry;
+
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 public class YoCompositeEditorPaneController
 {
@@ -115,11 +115,12 @@ public class YoCompositeEditorPaneController
          int supplierIndex = i;
 
          yoComponentTextField.supplierProperty().addListener((o, oldValue, newValue) ->
-         {
-            DoubleProperty[] newSuppliers = Arrays.copyOf(compositeSupplierProperty.get(), numberOfComponents);
-            newSuppliers[supplierIndex] = newValue;
-            compositeSupplierProperty.set(newSuppliers);
-         });
+                                                             {
+                                                                DoubleProperty[] newSuppliers = Arrays.copyOf(compositeSupplierProperty.get(),
+                                                                                                              numberOfComponents);
+                                                                newSuppliers[supplierIndex] = newValue;
+                                                                compositeSupplierProperty.set(newSuppliers);
+                                                             });
 
          yoComponentTextFields[i] = yoComponentTextField;
       }
@@ -140,15 +141,17 @@ public class YoCompositeEditorPaneController
       }
 
       compositeNameProperty.addListener((observable, oldValue, newValue) ->
-      {
-         if (newValue == null || newValue.isEmpty())
-         {
-            compositeNameProperty.set(oldValue);
-            return;
-         }
+                                        {
+                                           if (newValue == null || newValue.isEmpty())
+                                           {
+                                              compositeNameProperty.set(oldValue);
+                                              return;
+                                           }
 
-         searchYoCompositeLabel.setText(YoGraphicFXControllerTools.replaceAndMatchCase(searchYoCompositeLabel.getText(), oldValue, newValue));
-      });
+                                           searchYoCompositeLabel.setText(YoGraphicFXControllerTools.replaceAndMatchCase(searchYoCompositeLabel.getText(),
+                                                                                                                         oldValue,
+                                                                                                                         newValue));
+                                        });
    }
 
    private void createLayout()
@@ -296,7 +299,7 @@ public class YoCompositeEditorPaneController
       return compositeSupplierProperty;
    }
 
-   public ReadOnlyProperty<Property<ReferenceFrame>> frameSupplierProperty()
+   public ReadOnlyProperty<Property<ReferenceFrameWrapper>> frameSupplierProperty()
    {
       return yoReferenceFrameTextField.supplierProperty();
    }
@@ -313,7 +316,7 @@ public class YoCompositeEditorPaneController
       compositeSupplierProperty.addListener((o, oldValue, newValue) -> componentsConsumer.accept(newValue));
    }
 
-   public void addInputListener(BiConsumer<DoubleProperty[], Property<ReferenceFrame>> frameComponentsConsumer)
+   public void addInputListener(BiConsumer<DoubleProperty[], Property<ReferenceFrameWrapper>> frameComponentsConsumer)
    {
       compositeSupplierProperty.addListener((o, oldValue, newValue) -> frameComponentsConsumer.accept(newValue, yoReferenceFrameTextField.getSupplier()));
       frameSupplierProperty().addListener((o, oldValue, newValue) -> frameComponentsConsumer.accept(compositeSupplierProperty.get(), newValue));

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/YoCompositeEditorPaneController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/YoCompositeEditorPaneController.java
@@ -18,7 +18,6 @@ import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.scs2.definition.yoComposite.YoCompositeDefinition;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField.DoubleSearchField;
@@ -282,11 +281,11 @@ public class YoCompositeEditorPaneController
          yoCompositeTextField.initializeFieldFromComponents();
    }
 
-   public void setReferenceFrame(ReferenceFrame referenceFrame)
+   public void setReferenceFrame(ReferenceFrameWrapper referenceFrame)
    {
       if (yoReferenceFrameTextField == null)
          return;
-      referenceFrameSearchTextField.setText(referenceFrame.getNameId());
+      referenceFrameSearchTextField.setText(referenceFrame.getFullName());
    }
 
    public ObservableBooleanValue inputsValidityProperty()

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/PropertySearchField.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/PropertySearchField.java
@@ -1,10 +1,18 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField;
 
-import javafx.beans.property.*;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.*;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.TransferMode;
 import javafx.util.Callback;
 import org.controlsfx.control.textfield.AutoCompletionBinding;
 import org.controlsfx.control.textfield.AutoCompletionBinding.ISuggestionRequest;

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/ReferenceFrameSearchField.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/ReferenceFrameSearchField.java
@@ -64,10 +64,9 @@ public class ReferenceFrameSearchField extends PropertySearchField<Property<Refe
    @Override
    protected Callback<ISuggestionRequest, Collection<String>> createSuggestions()
    {
-      Collection<String> referenceFrameUniqueNames = referenceFrameManager.getReferenceFrameUniqueShortNames();
-
       return request ->
       {
+         Collection<String> referenceFrameUniqueNames = referenceFrameManager.getReferenceFrameUniqueShortNames();
          String userText = request.getUserText();
          if (userText.isEmpty())
             return referenceFrameUniqueNames;

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/ReferenceFrameSearchField.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/ReferenceFrameSearchField.java
@@ -48,13 +48,13 @@ public class ReferenceFrameSearchField extends PropertySearchField<Property<Refe
    protected String simplifyText(String text)
    {
       if (text == null)
-         return referenceFrameManager.getUniqueShortName(referenceFrameManager.getWorldFrame());
+         return referenceFrameManager.getWorldFrame().getUniqueShortName();
 
       ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(text);
       if (referenceFrame == null)
          return null;
 
-      String uniqueName = referenceFrameManager.getUniqueShortName(referenceFrame);
+      String uniqueName = referenceFrame.getUniqueShortName();
       if (uniqueName != null && uniqueName.equals(text))
          return null;
 

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/ReferenceFrameSearchField.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/editor/searchTextField/ReferenceFrameSearchField.java
@@ -1,23 +1,22 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.controlsfx.control.textfield.AutoCompletionBinding.ISuggestionRequest;
-
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.TextField;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.Dragboard;
 import javafx.util.Callback;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import org.controlsfx.control.textfield.AutoCompletionBinding.ISuggestionRequest;
 import us.ihmc.log.LogTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YoComposite;
 
-public class ReferenceFrameSearchField extends PropertySearchField<Property<ReferenceFrame>>
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ReferenceFrameSearchField extends PropertySearchField<Property<ReferenceFrameWrapper>>
 {
    private final ReferenceFrameManager referenceFrameManager;
 
@@ -39,7 +38,7 @@ public class ReferenceFrameSearchField extends PropertySearchField<Property<Refe
       if (text == null || text.isEmpty())
          return false;
 
-      ReferenceFrame referenceFrame = referenceFrameManager.getReferenceFrameFromUniqueName(text);
+      ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromUniqueName(text);
       if (referenceFrame == null)
          referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(text);
       return referenceFrame != null;
@@ -51,7 +50,7 @@ public class ReferenceFrameSearchField extends PropertySearchField<Property<Refe
       if (text == null)
          return referenceFrameManager.getUniqueShortName(referenceFrameManager.getWorldFrame());
 
-      ReferenceFrame referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(text);
+      ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(text);
       if (referenceFrame == null)
          return null;
 
@@ -74,19 +73,18 @@ public class ReferenceFrameSearchField extends PropertySearchField<Property<Refe
             return referenceFrameUniqueNames;
 
          String userTextLowerCase = userText.toLowerCase();
-         return referenceFrameUniqueNames.stream().filter(v -> v.toLowerCase().contains(userTextLowerCase))
-                                     .collect(Collectors.toList());
+         return referenceFrameUniqueNames.stream().filter(v -> v.toLowerCase().contains(userTextLowerCase)).collect(Collectors.toList());
       };
    }
 
    @Override
-   protected Property<ReferenceFrame> toSupplier(String text)
+   protected Property<ReferenceFrameWrapper> toSupplier(String text)
    {
-      ReferenceFrame referenceFrame = referenceFrameManager.getReferenceFrameFromUniqueName(text);
+      ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromUniqueName(text);
       if (referenceFrame == null)
          return null;
       else
-         return new SimpleObjectProperty<ReferenceFrame>(referenceFrame);
+         return new SimpleObjectProperty<>(referenceFrame);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicFXControllerTools.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicFXControllerTools.java
@@ -1,20 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.function.BiPredicate;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
-import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
-import org.reflections.util.ClasspathHelper;
-import org.reflections.util.ConfigurationBuilder;
-
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -26,8 +11,12 @@ import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.CompositePropertyTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple2DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
@@ -38,6 +27,16 @@ import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicFXItem;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGroupFX;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
 public class YoGraphicFXControllerTools
 {
    public static List<Class<? extends YoGraphicFXItem>> yoGraphicFXTypes;
@@ -47,20 +46,26 @@ public class YoGraphicFXControllerTools
    static
    {
       Thread loader = new Thread(() ->
-      {
-         Reflections reflections = new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(YoGraphicFXItem.class.getPackage().getName()))
-                                                                             .setScanners(new SubTypesScanner()));
-         Set<Class<? extends YoGraphicFXItem>> yoGraphicFXSubTypes = reflections.getSubTypesOf(YoGraphicFXItem.class);
-         yoGraphicFXTypes = yoGraphicFXSubTypes.stream().filter(type -> !Modifier.isAbstract(type.getModifiers()) && !type.isInterface())
-                                               .sorted((c1, c2) -> c1.getSimpleName().compareTo(c2.getSimpleName())).collect(Collectors.toList());
-         Set<Class<? extends YoGraphicFX2D>> yoGraphicFX2DSubTypes = reflections.getSubTypesOf(YoGraphicFX2D.class);
-         yoGraphicFX2DTypes = yoGraphicFX2DSubTypes.stream().filter(type -> !Modifier.isAbstract(type.getModifiers()) && !type.isInterface())
-                                                   .sorted((c1, c2) -> c1.getSimpleName().compareTo(c2.getSimpleName())).collect(Collectors.toList());
-         Set<Class<? extends YoGraphicFX3D>> yoGraphicFX3DSubTypes = reflections.getSubTypesOf(YoGraphicFX3D.class);
-         yoGraphicFX3DTypes = yoGraphicFX3DSubTypes.stream().filter(type -> !Modifier.isAbstract(type.getModifiers()) && !type.isInterface())
-                                                   .sorted((c1, c2) -> c1.getSimpleName().compareTo(c2.getSimpleName())).collect(Collectors.toList());
-
-      }, "YoGraphicFX Loader");
+                                 {
+                                    Reflections reflections = new Reflections(new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(YoGraphicFXItem.class.getPackage()
+                                                                                                                                                                 .getName()))
+                                                                                                        .setScanners(new SubTypesScanner()));
+                                    Set<Class<? extends YoGraphicFXItem>> yoGraphicFXSubTypes = reflections.getSubTypesOf(YoGraphicFXItem.class);
+                                    yoGraphicFXTypes = yoGraphicFXSubTypes.stream()
+                                                                          .filter(type -> !Modifier.isAbstract(type.getModifiers()) && !type.isInterface())
+                                                                          .sorted((c1, c2) -> c1.getSimpleName().compareTo(c2.getSimpleName()))
+                                                                          .collect(Collectors.toList());
+                                    Set<Class<? extends YoGraphicFX2D>> yoGraphicFX2DSubTypes = reflections.getSubTypesOf(YoGraphicFX2D.class);
+                                    yoGraphicFX2DTypes = yoGraphicFX2DSubTypes.stream()
+                                                                              .filter(type -> !Modifier.isAbstract(type.getModifiers()) && !type.isInterface())
+                                                                              .sorted((c1, c2) -> c1.getSimpleName().compareTo(c2.getSimpleName()))
+                                                                              .collect(Collectors.toList());
+                                    Set<Class<? extends YoGraphicFX3D>> yoGraphicFX3DSubTypes = reflections.getSubTypesOf(YoGraphicFX3D.class);
+                                    yoGraphicFX3DTypes = yoGraphicFX3DSubTypes.stream()
+                                                                              .filter(type -> !Modifier.isAbstract(type.getModifiers()) && !type.isInterface())
+                                                                              .sorted((c1, c2) -> c1.getSimpleName().compareTo(c2.getSimpleName()))
+                                                                              .collect(Collectors.toList());
+                                 }, "YoGraphicFX Loader");
       loader.setPriority(Thread.MIN_PRIORITY);
       loader.setDaemon(true);
       loader.start();
@@ -83,7 +88,7 @@ public class YoGraphicFXControllerTools
       return clone;
    }
 
-   public static YoGraphicFXItem createYoGraphicFXItemAndRegister(ReferenceFrame worldFrame,
+   public static YoGraphicFXItem createYoGraphicFXItemAndRegister(ReferenceFrameWrapper worldFrame,
                                                                   YoGroupFX parentGroup,
                                                                   String itemName,
                                                                   Class<? extends YoGraphicFXItem> itemTypeToInstantiate)
@@ -96,8 +101,7 @@ public class YoGraphicFXControllerTools
       }
       else if (YoGraphicFX.class.isAssignableFrom(itemTypeToInstantiate))
       {
-         @SuppressWarnings("unchecked")
-         YoGraphicFX item = newInstance(worldFrame, (Class<? extends YoGraphicFX>) itemTypeToInstantiate);
+         @SuppressWarnings("unchecked") YoGraphicFX item = newInstance(worldFrame, (Class<? extends YoGraphicFX>) itemTypeToInstantiate);
 
          item.setName(itemName);
          boolean success = parentGroup.addYoGraphicFXItem(item);
@@ -109,17 +113,18 @@ public class YoGraphicFXControllerTools
       }
    }
 
-   private static YoGraphicFX newInstance(ReferenceFrame worldFrame, Class<? extends YoGraphicFX> itemTypeToInstantiate)
+   private static YoGraphicFX newInstance(ReferenceFrameWrapper worldFrame, Class<? extends YoGraphicFX> itemTypeToInstantiate)
    {
       try
       {
-         Constructor<? extends YoGraphicFX> constructor = itemTypeToInstantiate.getConstructor(ReferenceFrame.class);
+         Constructor<? extends YoGraphicFX> constructor = itemTypeToInstantiate.getConstructor(ReferenceFrameWrapper.class);
          return constructor.newInstance(worldFrame);
       }
-      catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException
-            | InvocationTargetException e)
+      catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException |
+             InvocationTargetException e)
       {
-         throw new RuntimeException("Something went wrong when instantiating a YoGraphicFX attempting to invoke its constructor with ReferenceFrame argument: ", e);
+         throw new RuntimeException("Something went wrong when instantiating a YoGraphicFX attempting to invoke its constructor with ReferenceFrame argument: ",
+                                    e);
       }
    }
 
@@ -359,18 +364,18 @@ public class YoGraphicFXControllerTools
    public static ReadOnlyObjectProperty<List<Tuple2DProperty>> toTuple2DDoubleSupplierListProperty(ReadOnlyObjectProperty<List<DoubleProperty[]>> inputProperty)
    {
       ObjectProperty<List<Tuple2DProperty>> output = new SimpleObjectProperty<>(null, "tuple2DSupplierList", null);
-      inputProperty.addListener((o,
-                                 oldValue,
-                                 newValue) -> output.set(newValue.stream().map(array -> new Tuple2DProperty(null, array)).collect(Collectors.toList())));
+      inputProperty.addListener((o, oldValue, newValue) -> output.set(newValue.stream()
+                                                                              .map(array -> new Tuple2DProperty(null, array))
+                                                                              .collect(Collectors.toList())));
       return output;
    }
 
    public static ReadOnlyObjectProperty<List<Tuple3DProperty>> toTuple3DDoubleSupplierListProperty(ReadOnlyObjectProperty<List<DoubleProperty[]>> inputProperty)
    {
       ObjectProperty<List<Tuple3DProperty>> output = new SimpleObjectProperty<>(null, "tuple3DSupplierList", null);
-      inputProperty.addListener((o,
-                                 oldValue,
-                                 newValue) -> output.set(newValue.stream().map(array -> new Tuple3DProperty(null, array)).collect(Collectors.toList())));
+      inputProperty.addListener((o, oldValue, newValue) -> output.set(newValue.stream()
+                                                                              .map(array -> new Tuple3DProperty(null, array))
+                                                                              .collect(Collectors.toList())));
       return output;
    }
 

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicFXEditorController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicFXEditorController.java
@@ -1,10 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic;
 
-import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -18,13 +13,13 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.VBox;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.YoCompositeEditorPaneController;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.YoCompositeListEditorPaneController;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField.DoubleSearchField;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.searchTextField.ReferenceFrameSearchField;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic.editor.YoGraphicNameEditorPaneController;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SessionVisualizerToolkit;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.YoCompositeSearchManager;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.CompositeProperty;
@@ -36,6 +31,11 @@ import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YawPitchRollProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YoCompositeTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicFX;
 import us.ihmc.scs2.sharedMemory.LinkedYoRegistry;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public abstract class YoGraphicFXEditorController<G extends YoGraphicFX> implements YoGraphicFXCreatorController<G>
 {
@@ -78,7 +78,7 @@ public abstract class YoGraphicFXEditorController<G extends YoGraphicFX> impleme
       inputsValidityProperty = Bindings.and(inputsValidityProperty, yoDoubleTextField.getValidityProperty());
    }
 
-   protected void setupReferenceFramePropertyEditor(TextField textField, ImageView validImageView, BiConsumer<G, Property<ReferenceFrame>> setter)
+   protected void setupReferenceFramePropertyEditor(TextField textField, ImageView validImageView, BiConsumer<G, Property<ReferenceFrameWrapper>> setter)
    {
       ReferenceFrameManager referenceFrameManager = toolkit.getReferenceFrameManager();
       ReferenceFrameSearchField yoReferenceFrameTextField = new ReferenceFrameSearchField(textField, referenceFrameManager, validImageView);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicItemCreatorDialogController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicItemCreatorDialogController.java
@@ -23,11 +23,11 @@ import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import org.apache.commons.lang3.StringUtils;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.scs2.definition.robot.RobotDefinition;
 import us.ihmc.scs2.definition.terrain.TerrainObjectDefinition;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SessionVisualizerToolkit;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.YoRobotFXManager;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.*;
@@ -78,7 +78,7 @@ public class YoGraphicItemCreatorDialogController
    private final Map<Toggle, Class<? extends YoGraphicFXItem>> buttonToTypeMap = new LinkedHashMap<>();
    private final Map<Class<? extends YoGraphicFXItem>, String> typeToDefaultNameMap = new LinkedHashMap<>();
 
-   private ReferenceFrame worldFrame;
+   private ReferenceFrameWrapper worldFrame;
    private YoRobotFXManager robotFXManager;
    private ReferenceFrameManager referenceFrameManager;
    private ObservableList<RobotDefinition> sessionRobotDefinitions;

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicItemCreatorDialogController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/controllers/yoGraphic/YoGraphicItemCreatorDialogController.java
@@ -1,16 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic;
 
-import static us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic.YoGraphicFXControllerTools.createAvailableYoGraphicFXItemName;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.FXCollections;
@@ -33,6 +22,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import org.apache.commons.lang3.StringUtils;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.scs2.definition.robot.RobotDefinition;
 import us.ihmc.scs2.definition.terrain.TerrainObjectDefinition;
@@ -40,29 +30,16 @@ import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SessionVisualizerToolkit;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.YoRobotFXManager;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoArrowFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoBoxFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoCapsuleFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoConeFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoConvexPolytopeFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoCoordinateSystemFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoCylinderFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoEllipsoidFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicFX2D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicFXItem;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGraphicTools;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoGroupFX;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoLineFX2D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPointFX2D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPointFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPointcloudFX2D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPointcloudFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPolygonExtrudedFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPolygonFX2D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoPolynomialFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoRampFX3D;
-import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.YoSTPBoxFX3D;
+import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic.YoGraphicFXControllerTools.createAvailableYoGraphicFXItemName;
 
 public class YoGraphicItemCreatorDialogController
 {
@@ -71,9 +48,7 @@ public class YoGraphicItemCreatorDialogController
    @FXML
    private ToggleButton yoLineFX2DToggleButton, yoPointcloudFX2DToggleButton, yoPointFX2DToggleButton, yoPolygonFX2DToggleButton;
    @FXML
-   private ToggleButton yoArrowFX3DToggleButton, yoBoxFX3DToggleButton, yoCapsuleFX3DToggleButton, yoConeFX3DToggleButton, yoCoordinateSystemFX3DToggleButton,
-         yoCylinderFX3DToggleButton, yoEllipsoidFX3DToggleButton, yoPointcloudFX3DToggleButton, yoPointFX3DToggleButton, yoPolygonExtrudedFX3DToggleButton,
-         yoConvexPolytopeFX3DToggleButton, yoPolynomialFX3DToggleButton, yoRampFX3DToggleButton, yoSTPBoxFX3DToggleButton;
+   private ToggleButton yoArrowFX3DToggleButton, yoBoxFX3DToggleButton, yoCapsuleFX3DToggleButton, yoConeFX3DToggleButton, yoCoordinateSystemFX3DToggleButton, yoCylinderFX3DToggleButton, yoEllipsoidFX3DToggleButton, yoPointcloudFX3DToggleButton, yoPointFX3DToggleButton, yoPolygonExtrudedFX3DToggleButton, yoConvexPolytopeFX3DToggleButton, yoPolynomialFX3DToggleButton, yoRampFX3DToggleButton, yoSTPBoxFX3DToggleButton;
    @FXML
    private GridPane miscPane;
    @FXML
@@ -179,48 +154,52 @@ public class YoGraphicItemCreatorDialogController
       refreshRobotMassPropertiesToggleButtons();
 
       toggleGroup.selectedToggleProperty().addListener((observable, oldValue, newValue) ->
-      {
-         Class<? extends YoGraphicFXItem> newItemType;
-         String name;
+                                                       {
+                                                          Class<? extends YoGraphicFXItem> newItemType;
+                                                          String name;
 
-         if (robotCollisionsToggleButtons.contains(newValue))
-         {
-            newItemType = YoGroupFX.class;
-            name = sessionRobotDefinitions.get(robotCollisionsToggleButtons.indexOf(newValue)).getName() + " collisions";
-         }
-         else if (terrainCollisionsToggleButton != null && terrainCollisionsToggleButton == newValue)
-         {
-            newItemType = YoGroupFX.class;
-            name = "Terrain collisions";
-         }
-         else if (robotMassPropertiesToggleButtons.contains(newValue))
-         {
-            newItemType = YoGroupFX.class;
-            name = sessionRobotDefinitions.get(robotMassPropertiesToggleButtons.indexOf(newValue)).getName() + " mass properties";
-         }
-         else
-         {
-            newItemType = toItemType(newValue);
-            name = typeToDefaultNameMap.get(newItemType);
-         }
+                                                          if (robotCollisionsToggleButtons.contains(newValue))
+                                                          {
+                                                             newItemType = YoGroupFX.class;
+                                                             name = sessionRobotDefinitions.get(robotCollisionsToggleButtons.indexOf(newValue)).getName()
+                                                                    + " collisions";
+                                                          }
+                                                          else if (terrainCollisionsToggleButton != null && terrainCollisionsToggleButton == newValue)
+                                                          {
+                                                             newItemType = YoGroupFX.class;
+                                                             name = "Terrain collisions";
+                                                          }
+                                                          else if (robotMassPropertiesToggleButtons.contains(newValue))
+                                                          {
+                                                             newItemType = YoGroupFX.class;
+                                                             name = sessionRobotDefinitions.get(robotMassPropertiesToggleButtons.indexOf(newValue)).getName()
+                                                                    + " mass properties";
+                                                          }
+                                                          else
+                                                          {
+                                                             newItemType = toItemType(newValue);
+                                                             name = typeToDefaultNameMap.get(newItemType);
+                                                          }
 
-         name = newItemType == null ? "" : createAvailableYoGraphicFXItemName(parent, name, newItemType);
+                                                          name = newItemType == null ? "" : createAvailableYoGraphicFXItemName(parent, name, newItemType);
 
-         itemNameTextField.setText(name);
-         itemNameValidityProperty.set(isYoGraphicFXItemNameValid(name, newItemType));
-      });
+                                                          itemNameTextField.setText(name);
+                                                          itemNameValidityProperty.set(isYoGraphicFXItemNameValid(name, newItemType));
+                                                       });
 
       itemNameTextField.textProperty().addListener((observable, oldValue, newValue) ->
-      {
-         if (robotCollisionsToggleButtons.contains(toggleGroup.getSelectedToggle()))
-            itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, YoGroupFX.class));
-         else if (terrainCollisionsToggleButton != null && terrainCollisionsToggleButton == toggleGroup.getSelectedToggle())
-            itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, YoGroupFX.class));
-         else if (robotMassPropertiesToggleButtons.contains(toggleGroup.getSelectedToggle()))
-            itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, YoGroupFX.class));
-         else
-            itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, toItemType(toggleGroup.getSelectedToggle())));
-      });
+                                                   {
+                                                      if (robotCollisionsToggleButtons.contains(toggleGroup.getSelectedToggle()))
+                                                         itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, YoGroupFX.class));
+                                                      else if (terrainCollisionsToggleButton != null
+                                                               && terrainCollisionsToggleButton == toggleGroup.getSelectedToggle())
+                                                         itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, YoGroupFX.class));
+                                                      else if (robotMassPropertiesToggleButtons.contains(toggleGroup.getSelectedToggle()))
+                                                         itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue, YoGroupFX.class));
+                                                      else
+                                                         itemNameValidityProperty.set(isYoGraphicFXItemNameValid(newValue,
+                                                                                                                 toItemType(toggleGroup.getSelectedToggle())));
+                                                   });
       YoGraphicFXControllerTools.bindValidityImageView(itemNameValidityProperty, itemNameValidImageView);
 
       createItemButton.disableProperty().bind(itemNameValidityProperty.not());
@@ -354,7 +333,8 @@ public class YoGraphicItemCreatorDialogController
       {
          RobotDefinition robotDefinition = sessionRobotDefinitions.get(robotCollisionsToggleButtons.indexOf(toggleGroup.getSelectedToggle()));
          YoGroupFX robotCollisionShapeDefinitions = YoGraphicTools.convertRobotCollisionShapeDefinitions(robotFXManager.getRobotRootBody(robotDefinition.getName()),
-                                                                                                         robotDefinition);
+                                                                                                         robotDefinition,
+                                                                                                         referenceFrameManager);
          robotCollisionShapeDefinitions.setName(itemNameTextField.getText());
          boolean success = parent.addChild(robotCollisionShapeDefinitions);
          return success ? robotCollisionShapeDefinitions : null;
@@ -370,8 +350,8 @@ public class YoGraphicItemCreatorDialogController
       else if (robotMassPropertiesToggleButtons.contains(toggleGroup.getSelectedToggle()))
       {
          RobotDefinition robotDefinition = sessionRobotDefinitions.get(robotMassPropertiesToggleButtons.indexOf(toggleGroup.getSelectedToggle()));
-         YoGroupFX robotMassPropertiesShapeDefinitions = YoGraphicTools.convertRobotMassPropertiesShapeDefinitions(robotFXManager.getRobotRootBody(robotDefinition.getName()),
-                                                                                                                   robotDefinition);
+         YoGroupFX robotMassPropertiesShapeDefinitions = YoGraphicTools.convertRobotMassPropertiesShapeDefinitions(robotFXManager.getRobotRootBody(
+               robotDefinition.getName()), robotDefinition, referenceFrameManager);
          robotMassPropertiesShapeDefinitions.setName(itemNameTextField.getText());
          boolean success = parent.addChild(robotMassPropertiesShapeDefinitions);
          return success ? robotMassPropertiesShapeDefinitions : null;

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
@@ -1,14 +1,24 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.managers;
 
+import us.ihmc.euclid.interfaces.Transformable;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 
 public class ReferenceFrameWrapper
 {
    private static final RigidBodyTransformReadOnly IDENTITY = new RigidBodyTransform();
    private final String name;
-   private final String fullName;
+   private String fullName;
+   private List<String> namespace;
+   private String uniqueName;
+   private String uniqueShortName;
    private ReferenceFrame referenceFrame;
 
    public ReferenceFrameWrapper(String name, String fullName)
@@ -38,14 +48,58 @@ public class ReferenceFrameWrapper
       return fullName;
    }
 
+   public String getUniqueName()
+   {
+      return uniqueName;
+   }
+
+   public String getUniqueShortName()
+   {
+      if (uniqueShortName == null)
+      {
+         int firstSeparatorIndex = uniqueName.indexOf(".");
+         int lastSeparatorIndex = uniqueName.lastIndexOf(".");
+         if (firstSeparatorIndex != lastSeparatorIndex)
+            uniqueShortName = uniqueName.substring(0, firstSeparatorIndex) + "..." + uniqueName.substring(lastSeparatorIndex + 1);
+         else
+            uniqueShortName = uniqueName;
+      }
+
+      return uniqueShortName;
+   }
+
+   public List<String> getNamespace()
+   {
+      if (namespace == null)
+      {
+         namespace = Arrays.asList(fullName.split(ReferenceFrame.SEPARATOR));
+         namespace = namespace.subList(0, namespace.size() - 1);
+      }
+      return namespace;
+   }
+
    public ReferenceFrame getReferenceFrame()
    {
       return referenceFrame;
    }
 
+   public void setUniqueName(String uniqueName)
+   {
+      this.uniqueName = uniqueName;
+      uniqueShortName = null;
+   }
+
    public void setReferenceFrame(ReferenceFrame referenceFrame)
    {
+      if (!Objects.equals(name, referenceFrame.getName()))
+      {
+         throw new IllegalArgumentException(
+               "The name of the reference frame does not match the name of this wrapper: " + name + " vs " + referenceFrame.getName());
+      }
+
       this.referenceFrame = referenceFrame;
+      fullName = referenceFrame.getNameId();
+      namespace = null;
    }
 
    public boolean isDefined()
@@ -65,5 +119,50 @@ public class ReferenceFrameWrapper
          return IDENTITY;
       else
          return referenceFrame.getTransformToRoot();
+   }
+
+   public <T extends Transformable> T transformFromThisToDesiredFrame(ReferenceFrameWrapper desiredFrame, T transformable)
+   {
+      if (referenceFrame != null && desiredFrame.referenceFrame != null)
+         referenceFrame.transformFromThisToDesiredFrame(desiredFrame.referenceFrame, transformable);
+      return transformable;
+   }
+
+   public <T extends Transformable> T transformToRootFrame(T transformable)
+   {
+      if (referenceFrame != null && !referenceFrame.isRootFrame())
+         referenceFrame.transformFromThisToDesiredFrame(referenceFrame.getRootFrame(), transformable);
+      return transformable;
+   }
+
+   public List<ReferenceFrameWrapper> collectSubtree()
+   {
+      if (referenceFrame == null)
+         return List.of(this);
+      else
+         return collectSubtree(this, new ArrayList<>());
+   }
+
+   private static <T extends Collection<ReferenceFrameWrapper>> T collectSubtree(ReferenceFrameWrapper start, T collectionToPack)
+   {
+      collectionToPack.add(start);
+
+      if (start.referenceFrame != null)
+      {
+         for (int i = 0; i < start.referenceFrame.getNumberOfChildren(); i++)
+         {
+            ReferenceFrame child = start.referenceFrame.getChild(i);
+            if (child != null)
+               collectSubtree(new ReferenceFrameWrapper(child), collectionToPack);
+         }
+      }
+
+      return collectionToPack;
+   }
+
+   public void clearChildren()
+   {
+      if (referenceFrame != null)
+         referenceFrame.clearChildren();
    }
 }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
@@ -12,6 +12,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * Wrapper around a {@link ReferenceFrame} to provide the ability to have undefined reference frames and other minor utilities.
+ */
 public class ReferenceFrameWrapper
 {
    private static final RigidBodyTransformReadOnly IDENTITY = new RigidBodyTransform();

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
@@ -165,4 +165,10 @@ public class ReferenceFrameWrapper
       if (referenceFrame != null)
          referenceFrame.clearChildren();
    }
+
+   @Override
+   public String toString()
+   {
+      return "%s{name='%s', fullName='%s'}".formatted(getClass().getSimpleName(), name, fullName);
+   }
 }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
@@ -4,6 +4,7 @@ import us.ihmc.euclid.interfaces.Transformable;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.scs2.sessionVisualizer.jfx.tools.WeakList;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,6 +21,7 @@ public class ReferenceFrameWrapper
    private String uniqueName;
    private String uniqueShortName;
    private ReferenceFrame referenceFrame;
+   private final WeakList<Runnable> changeListeners = new WeakList<>();
 
    public ReferenceFrameWrapper(String name, String fullName)
    {
@@ -103,6 +105,7 @@ public class ReferenceFrameWrapper
       this.referenceFrame = referenceFrame;
       fullName = referenceFrame.getNameId();
       namespace = null;
+      changeListeners.forEach(Runnable::run);
    }
 
    public boolean isDefined()
@@ -167,6 +170,16 @@ public class ReferenceFrameWrapper
    {
       if (referenceFrame != null)
          referenceFrame.clearChildren();
+   }
+
+   public void addChangeListener(Runnable listener)
+   {
+      changeListeners.add(listener);
+   }
+
+   public void removeChangeListener(Runnable listener)
+   {
+      changeListeners.remove(listener);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
@@ -91,6 +91,9 @@ public class ReferenceFrameWrapper
 
    public void setReferenceFrame(ReferenceFrame referenceFrame)
    {
+      if (referenceFrame == this.referenceFrame)
+         return;
+
       if (!Objects.equals(name, referenceFrame.getName()))
       {
          throw new IllegalArgumentException(

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/ReferenceFrameWrapper.java
@@ -1,0 +1,69 @@
+package us.ihmc.scs2.sessionVisualizer.jfx.managers;
+
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+
+public class ReferenceFrameWrapper
+{
+   private static final RigidBodyTransformReadOnly IDENTITY = new RigidBodyTransform();
+   private final String name;
+   private final String fullName;
+   private ReferenceFrame referenceFrame;
+
+   public ReferenceFrameWrapper(String name, String fullName)
+   {
+      this(name, fullName, null);
+   }
+
+   public ReferenceFrameWrapper(ReferenceFrame referenceFrame)
+   {
+      this(referenceFrame.getName(), referenceFrame.getNameId(), referenceFrame);
+   }
+
+   private ReferenceFrameWrapper(String name, String fullName, ReferenceFrame referenceFrame)
+   {
+      this.name = name;
+      this.fullName = fullName;
+      this.referenceFrame = referenceFrame;
+   }
+
+   public String getName()
+   {
+      return name;
+   }
+
+   public String getFullName()
+   {
+      return fullName;
+   }
+
+   public ReferenceFrame getReferenceFrame()
+   {
+      return referenceFrame;
+   }
+
+   public void setReferenceFrame(ReferenceFrame referenceFrame)
+   {
+      this.referenceFrame = referenceFrame;
+   }
+
+   public boolean isDefined()
+   {
+      return referenceFrame != null;
+   }
+
+   public boolean isRootFrame()
+   {
+      // Making undefined reference frames root frames.
+      return !isDefined() || referenceFrame.isRootFrame();
+   }
+
+   public RigidBodyTransformReadOnly getTransformToRoot()
+   {
+      if (referenceFrame == null)
+         return IDENTITY;
+      else
+         return referenceFrame.getTransformToRoot();
+   }
+}

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/SessionVisualizerToolkit.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/SessionVisualizerToolkit.java
@@ -7,7 +7,6 @@ import javafx.collections.ObservableList;
 import javafx.scene.Group;
 import javafx.scene.SubScene;
 import javafx.stage.Stage;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.log.LogTools;
 import us.ihmc.messager.MessagerAPIFactory;
 import us.ihmc.scs2.definition.robot.RobotDefinition;
@@ -315,7 +314,7 @@ public class SessionVisualizerToolkit extends ObservedAnimationTimer
       return yoCompositeSearchManager;
    }
 
-   public ReferenceFrame getWorldFrame()
+   public ReferenceFrameWrapper getWorldFrame()
    {
       return referenceFrameManager.getWorldFrame();
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/CompositePropertyTools.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/CompositePropertyTools.java
@@ -222,8 +222,9 @@ public class CompositePropertyTools
       if (referenceFrame != null)
          return new SimpleObjectProperty<>(referenceFrame);
 
-      LogTools.warn("Could not retrieve the frame {} using world instead (fullname: {})", fieldShort, field);
-      return new SimpleObjectProperty<>(referenceFrameManager.getWorldFrame());
+      LogTools.warn("Could not retrieve the frame {}. Could be a robot frame that is yet to be loaded (fullname: {}).", fieldShort, field);
+      referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(field, true);
+      return new SimpleObjectProperty<>(referenceFrame);
    }
 
    public static String toDoublePropertyName(DoubleProperty doubleProperty)

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/CompositePropertyTools.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/CompositePropertyTools.java
@@ -1,9 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.tools;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.Property;
@@ -19,6 +15,7 @@ import us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition;
 import us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition;
 import us.ihmc.scs2.definition.yoComposite.YoYawPitchRollDefinition;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.properties.YoDoubleProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.properties.YoIntegerProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.CompositeProperty;
@@ -29,6 +26,10 @@ import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.YawPitchRollProperty;
 import us.ihmc.yoVariables.variable.YoDouble;
 import us.ihmc.yoVariables.variable.YoInteger;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CompositePropertyTools
 {
@@ -194,14 +195,14 @@ public class CompositePropertyTools
       }
    }
 
-   public static Property<ReferenceFrame> toReferenceFrameProperty(YoVariableDatabase yoVariableDatabase,
-                                                                   ReferenceFrameManager referenceFrameManager,
-                                                                   String field)
+   public static Property<ReferenceFrameWrapper> toReferenceFrameProperty(YoVariableDatabase yoVariableDatabase,
+                                                                          ReferenceFrameManager referenceFrameManager,
+                                                                          String field)
    {
       if (field == null)
          return null;
 
-      ReferenceFrame referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(field);
+      ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(field);
 
       if (referenceFrame != null)
          return new SimpleObjectProperty<>(referenceFrame);
@@ -245,12 +246,12 @@ public class CompositePropertyTools
          return Integer.toString(integerProperty.get());
    }
 
-   public static String toReferenceFramePropertyName(Property<ReferenceFrame> referenceFrameProperty)
+   public static String toReferenceFramePropertyName(Property<ReferenceFrameWrapper> referenceFrameProperty)
    {
       if (referenceFrameProperty == null || referenceFrameProperty.getValue() == null)
          return null;
       else if (referenceFrameProperty instanceof SimpleObjectProperty)
-         return referenceFrameProperty.getValue().getNameId();
+         return referenceFrameProperty.getValue().getFullName();
       else
          throw new UnsupportedOperationException("Unhandled property: " + referenceFrameProperty.getClass().getSimpleName());
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/JavaFXMissingTools.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/JavaFXMissingTools.java
@@ -18,7 +18,12 @@ import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.DrawMode;
 import javafx.scene.shape.Shape3D;
-import javafx.scene.transform.*;
+import javafx.scene.transform.Affine;
+import javafx.scene.transform.NonInvertibleTransformException;
+import javafx.scene.transform.Rotate;
+import javafx.scene.transform.Scale;
+import javafx.scene.transform.Transform;
+import javafx.scene.transform.Translate;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
@@ -31,8 +36,14 @@ import us.ihmc.euclid.matrix.interfaces.RotationMatrixReadOnly;
 import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
 import us.ihmc.euclid.transform.AffineTransform;
 import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.euclid.tuple2D.interfaces.Tuple2DReadOnly;
-import us.ihmc.euclid.tuple3D.interfaces.*;
+import us.ihmc.euclid.tuple3D.interfaces.Point3DBasics;
+import us.ihmc.euclid.tuple3D.interfaces.Point3DReadOnly;
+import us.ihmc.euclid.tuple3D.interfaces.Tuple3DBasics;
+import us.ihmc.euclid.tuple3D.interfaces.Tuple3DReadOnly;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
 import us.ihmc.log.LogTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
 
@@ -476,20 +487,27 @@ public class JavaFXMissingTools
                           jfxTransform.getTz());
    }
 
-   public static void toJavaFX(RigidBodyTransform euclidTransform, javafx.scene.transform.Affine jfxTransform)
+   public static void toJavaFX(RigidBodyTransformReadOnly euclidTransform, javafx.scene.transform.Affine jfxTransform)
    {
-      jfxTransform.setToTransform(euclidTransform.getM00(),
-                                  euclidTransform.getM01(),
-                                  euclidTransform.getM02(),
-                                  euclidTransform.getM03(),
-                                  euclidTransform.getM10(),
-                                  euclidTransform.getM11(),
-                                  euclidTransform.getM12(),
-                                  euclidTransform.getM13(),
-                                  euclidTransform.getM20(),
-                                  euclidTransform.getM21(),
-                                  euclidTransform.getM22(),
-                                  euclidTransform.getM23());
+      if (euclidTransform instanceof RigidBodyTransform matrixTransform)
+      {
+         jfxTransform.setToTransform(matrixTransform.getM00(),
+                                     matrixTransform.getM01(),
+                                     matrixTransform.getM02(),
+                                     matrixTransform.getM03(),
+                                     matrixTransform.getM10(),
+                                     matrixTransform.getM11(),
+                                     matrixTransform.getM12(),
+                                     matrixTransform.getM13(),
+                                     matrixTransform.getM20(),
+                                     matrixTransform.getM21(),
+                                     matrixTransform.getM22(),
+                                     matrixTransform.getM23());
+      }
+      else
+      {
+         toJavaFX(new RigidBodyTransform(euclidTransform), jfxTransform);
+      }
    }
 
    public static javafx.geometry.Point3D toJavaFX(Tuple3DReadOnly euclidInput)

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/WeakList.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/WeakList.java
@@ -1,0 +1,156 @@
+package us.ihmc.scs2.sessionVisualizer.jfx.tools;
+
+import java.lang.ref.WeakReference;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Objects;
+
+public class WeakList<E> extends AbstractList<E> //implements List<E>, RandomAccess
+{
+   private final ArrayList<WeakReference<E>> elements;
+   private ElementGarbageCollectedListener listener;
+
+   public WeakList()
+   {
+      elements = new ArrayList<>();
+   }
+
+   public ElementGarbageCollectedListener setGCListener(ElementGarbageCollectedListener listener)
+   {
+      ElementGarbageCollectedListener oldListener = this.listener;
+      this.listener = listener;
+      return oldListener;
+   }
+
+   public ElementGarbageCollectedListener removeGCListener()
+   {
+      return setGCListener(null);
+   }
+
+   @Override
+   public int size()
+   {
+      return elements.size();
+   }
+
+   public void cleanupReferences()
+   {
+      for (int i = elements.size() - 1; i >= 0; i--)
+      {
+         if (elements.get(i).get() == null)
+         {
+            removeGCedElement(i);
+         }
+      }
+   }
+
+   private void removeGCedElement(int i)
+   {
+      elements.remove(i);
+      if (listener != null)
+         listener.onCleanup(i);
+   }
+
+   @Override
+   public E get(int index)
+   {
+      E element = elements.get(index).get();
+      while (element == null)
+      {
+         removeGCedElement(index);
+
+         if (index >= elements.size())
+            return null;
+
+         element = elements.get(index).get();
+      }
+      return element;
+   }
+
+   @Override
+   public E set(int index, E element)
+   {
+      Objects.requireNonNull(element);
+      WeakReference<E> elementReplaced = elements.set(index, new WeakReference<>(element));
+      return elementReplaced == null ? null : elementReplaced.get();
+   }
+
+   @Override
+   public void add(int index, E element)
+   {
+      Objects.requireNonNull(element);
+      elements.add(index, new WeakReference<>(element));
+   }
+
+   @Override
+   public E remove(int index)
+   {
+      WeakReference<E> elementRemoved = elements.remove(index);
+      return elementRemoved == null ? null : elementRemoved.get();
+   }
+
+   @Override
+   public int indexOf(Object query)
+   {
+      Objects.requireNonNull(query);
+      for (int i = 0; i < elements.size(); )
+      {
+         E candidate = elements.get(i).get();
+
+         if (candidate == null)
+            removeGCedElement(i);
+         else if (query.equals(candidate))
+            return i;
+         else
+            i++;
+      }
+      return -1;
+   }
+
+   @Override
+   public int lastIndexOf(Object query)
+   {
+      Objects.requireNonNull(query);
+      cleanupReferences();
+      for (int i = elements.size() - 1; i >= 0; i--)
+      {
+         E candidate = elements.get(i).get();
+
+         if (candidate == null)
+            removeGCedElement(i);
+         else if (query.equals(candidate))
+            return i;
+      }
+      return -1;
+   }
+
+   @Override
+   public void clear()
+   {
+      elements.clear();
+   }
+
+   @Override
+   public boolean equals(Object o)
+   {
+      cleanupReferences();
+      return super.equals(o);
+   }
+
+   @Override
+   public int hashCode()
+   {
+      int hashCode = 1;
+      for (int i = 0; i < size(); i++)
+      {
+         E e = get(i);
+         hashCode = 31 * hashCode + (e == null ? 0 : e.hashCode());
+      }
+      return hashCode;
+   }
+
+   public interface ElementGarbageCollectedListener
+   {
+      void onCleanup(int itemCollectedIndex);
+   }
+}

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/CompositeProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/CompositeProperty.java
@@ -1,8 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
-import java.util.Arrays;
-import java.util.stream.DoubleStream;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
@@ -14,13 +11,17 @@ import us.ihmc.euclid.tuple2D.Point2D;
 import us.ihmc.euclid.tuple2D.Vector2D;
 import us.ihmc.euclid.tuple2D.interfaces.Point2DReadOnly;
 import us.ihmc.euclid.tuple2D.interfaces.Vector2DReadOnly;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
+
+import java.util.Arrays;
+import java.util.stream.DoubleStream;
 
 public class CompositeProperty implements ReferenceFrameHolder
 {
    protected final String type;
    protected final String[] componentIdentifiers;
    protected DoubleProperty[] componentValueProperties;
-   protected Property<ReferenceFrame> referenceFrameProperty;
+   protected Property<ReferenceFrameWrapper> referenceFrameProperty;
 
    public CompositeProperty(String type, String[] componentIdentifiers)
    {
@@ -33,7 +34,7 @@ public class CompositeProperty implements ReferenceFrameHolder
       this(type, componentIdentifiers, null, componentValues);
    }
 
-   public CompositeProperty(String type, String[] componentIdentifiers, ReferenceFrame referenceFrame, double... componentValues)
+   public CompositeProperty(String type, String[] componentIdentifiers, ReferenceFrameWrapper referenceFrame, double... componentValues)
    {
       this(type, componentIdentifiers);
       set(referenceFrame, componentValues);
@@ -46,7 +47,7 @@ public class CompositeProperty implements ReferenceFrameHolder
 
    public CompositeProperty(String type,
                             String[] componentIdentifiers,
-                            Property<ReferenceFrame> referenceFrameProperty,
+                            Property<ReferenceFrameWrapper> referenceFrameProperty,
                             DoubleProperty... componentValueProperties)
    {
       this(type, componentIdentifiers);
@@ -65,20 +66,20 @@ public class CompositeProperty implements ReferenceFrameHolder
       if (!type.equals(other.type))
          throw new IllegalArgumentException("Incompatible composite type: this=" + type + ", other=" + other.type);
       if (!Arrays.deepEquals(componentIdentifiers, other.componentIdentifiers))
-         throw new IllegalArgumentException("Incompatible composite identifiers: this=" + Arrays.toString(componentIdentifiers) + ", other="
-               + Arrays.toString(componentIdentifiers));
+         throw new IllegalArgumentException(
+               "Incompatible composite identifiers: this=" + Arrays.toString(componentIdentifiers) + ", other=" + Arrays.toString(componentIdentifiers));
 
       componentValueProperties = Arrays.copyOf(other.componentValueProperties, other.componentValueProperties.length);
       referenceFrameProperty = other.referenceFrameProperty;
    }
 
-   public final void set(ReferenceFrame referenceFrame, double... componentValues)
+   public final void set(ReferenceFrameWrapper referenceFrame, double... componentValues)
    {
       setComponentValues(componentValues);
       setReferenceFrame(referenceFrame);
    }
 
-   public final void set(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty... componentValueProperties)
+   public final void set(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty... componentValueProperties)
    {
       setComponentValueProperties(componentValueProperties);
       setReferenceFrameProperty(referenceFrameProperty);
@@ -94,12 +95,12 @@ public class CompositeProperty implements ReferenceFrameHolder
       this.componentValueProperties = componentValueProperties;
    }
 
-   public final void setReferenceFrame(ReferenceFrame referenceFrame)
+   public final void setReferenceFrame(ReferenceFrameWrapper referenceFrame)
    {
       setReferenceFrameProperty(new SimpleObjectProperty<>(referenceFrame));
    }
 
-   public final void setReferenceFrameProperty(Property<ReferenceFrame> referenceFrameProperty)
+   public final void setReferenceFrameProperty(Property<ReferenceFrameWrapper> referenceFrameProperty)
    {
       this.referenceFrameProperty = referenceFrameProperty;
    }
@@ -119,7 +120,7 @@ public class CompositeProperty implements ReferenceFrameHolder
       return componentValueProperties;
    }
 
-   public final Property<ReferenceFrame> referenceFrameProperty()
+   public final Property<ReferenceFrameWrapper> referenceFrameProperty()
    {
       return referenceFrameProperty;
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/CompositeProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/CompositeProperty.java
@@ -5,8 +5,6 @@ import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import us.ihmc.euclid.interfaces.Transformable;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.euclid.referenceFrame.interfaces.ReferenceFrameHolder;
 import us.ihmc.euclid.tuple2D.Point2D;
 import us.ihmc.euclid.tuple2D.Vector2D;
 import us.ihmc.euclid.tuple2D.interfaces.Point2DReadOnly;
@@ -16,7 +14,7 @@ import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import java.util.Arrays;
 import java.util.stream.DoubleStream;
 
-public class CompositeProperty implements ReferenceFrameHolder
+public class CompositeProperty
 {
    protected final String type;
    protected final String[] componentIdentifiers;
@@ -125,8 +123,7 @@ public class CompositeProperty implements ReferenceFrameHolder
       return referenceFrameProperty;
    }
 
-   @Override
-   public final ReferenceFrame getReferenceFrame()
+   public final ReferenceFrameWrapper getReferenceFrame()
    {
       return referenceFrameProperty().getValue();
    }
@@ -161,20 +158,19 @@ public class CompositeProperty implements ReferenceFrameHolder
 
    public <T extends Transformable> T toWorld(T transformable)
    {
-      if (referenceFrameProperty() == null || getReferenceFrame() == null || getReferenceFrame().isRootFrame())
+      if (referenceFrameProperty() == null || getReferenceFrame() == null)
          return transformable;
 
-      getReferenceFrame().transformFromThisToDesiredFrame(getReferenceFrame().getRootFrame(), transformable);
-      return transformable;
+      return getReferenceFrame().transformToRootFrame(transformable);
    }
 
    @Override
    public final String toString()
    {
-      String description = "[" + type;
+      StringBuilder description = new StringBuilder("[" + type);
       for (int i = 0; i < componentIdentifiers.length; i++)
-         description += ", " + componentIdentifiers[i] + ": " + componentValueProperties[i];
-      description += ", frame: " + referenceFrameProperty + "]";
-      return description;
+         description.append(", ").append(componentIdentifiers[i]).append(": ").append(componentValueProperties[i]);
+      description.append(", frame: ").append(referenceFrameProperty).append("]");
+      return description.toString();
    }
 }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Orientation3DProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Orientation3DProperty.java
@@ -2,11 +2,11 @@ package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
-import us.ihmc.euclid.referenceFrame.interfaces.FrameOrientation3DReadOnly;
+import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
 import us.ihmc.euclid.tuple4D.Quaternion;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 
-public abstract class Orientation3DProperty extends CompositeProperty implements FrameOrientation3DReadOnly
+public abstract class Orientation3DProperty extends CompositeProperty implements Orientation3DReadOnly
 {
    public Orientation3DProperty(String type, String[] componentIdentifiers)
    {

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Orientation3DProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Orientation3DProperty.java
@@ -2,9 +2,9 @@ package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameOrientation3DReadOnly;
 import us.ihmc.euclid.tuple4D.Quaternion;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 
 public abstract class Orientation3DProperty extends CompositeProperty implements FrameOrientation3DReadOnly
 {
@@ -18,7 +18,7 @@ public abstract class Orientation3DProperty extends CompositeProperty implements
       super(type, componentIdentifiers, componentValues);
    }
 
-   public Orientation3DProperty(String type, String[] componentIdentifiers, ReferenceFrame referenceFrame, double... componentValues)
+   public Orientation3DProperty(String type, String[] componentIdentifiers, ReferenceFrameWrapper referenceFrame, double... componentValues)
    {
       super(type, componentIdentifiers, referenceFrame, componentValues);
    }
@@ -28,8 +28,10 @@ public abstract class Orientation3DProperty extends CompositeProperty implements
       super(type, componentIdentifiers, componentValueProperties);
    }
 
-   public Orientation3DProperty(String type, String[] componentIdentifiers, Property<ReferenceFrame> referenceFrameProperty,
-                                      DoubleProperty... componentValueProperties)
+   public Orientation3DProperty(String type,
+                                String[] componentIdentifiers,
+                                Property<ReferenceFrameWrapper> referenceFrameProperty,
+                                DoubleProperty... componentValueProperties)
    {
       super(type, componentIdentifiers, referenceFrameProperty, componentValueProperties);
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/QuaternionProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/QuaternionProperty.java
@@ -1,15 +1,15 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
-import static us.ihmc.scs2.definition.yoComposite.YoQuaternionDefinition.YoQuaternion;
-import static us.ihmc.scs2.definition.yoComposite.YoQuaternionDefinition.YoQuaternionIdentifiers;
-
-import java.util.Objects;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameQuaternionReadOnly;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
+
+import java.util.Objects;
+
+import static us.ihmc.scs2.definition.yoComposite.YoQuaternionDefinition.YoQuaternion;
+import static us.ihmc.scs2.definition.yoComposite.YoQuaternionDefinition.YoQuaternionIdentifiers;
 
 public class QuaternionProperty extends Orientation3DProperty implements FrameQuaternionReadOnly
 {
@@ -23,7 +23,7 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
       super(YoQuaternion, YoQuaternionIdentifiers, x, y, z, s);
    }
 
-   public QuaternionProperty(ReferenceFrame referenceFrame, double x, double y, double z, double s)
+   public QuaternionProperty(ReferenceFrameWrapper referenceFrame, double x, double y, double z, double s)
    {
       super(YoQuaternion, YoQuaternionIdentifiers, referenceFrame, x, y, z, s);
    }
@@ -33,7 +33,7 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
       super(YoQuaternion, YoQuaternionIdentifiers, xyzsProperties);
    }
 
-   public QuaternionProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty[] xyzsProperties)
+   public QuaternionProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty[] xyzsProperties)
    {
       super(YoQuaternion, YoQuaternionIdentifiers, referenceFrameProperty, xyzsProperties);
    }
@@ -43,8 +43,11 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
       super(YoQuaternion, YoQuaternionIdentifiers, xProperty, yProperty, zProperty, sProperty);
    }
 
-   public QuaternionProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty,
-                                   DoubleProperty zProperty, DoubleProperty sProperty)
+   public QuaternionProperty(Property<ReferenceFrameWrapper> referenceFrameProperty,
+                             DoubleProperty xProperty,
+                             DoubleProperty yProperty,
+                             DoubleProperty zProperty,
+                             DoubleProperty sProperty)
    {
       super(YoQuaternion, YoQuaternionIdentifiers, referenceFrameProperty, xProperty, yProperty, zProperty, sProperty);
    }
@@ -100,7 +103,7 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
       setComponentValues(x, y, z, s);
    }
 
-   public void set(ReferenceFrame referenceFrame, double x, double y, double z, double s)
+   public void set(ReferenceFrameWrapper referenceFrame, double x, double y, double z, double s)
    {
       set(referenceFrame, x, y, z, s);
    }
@@ -110,7 +113,10 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
       setComponentValueProperties(xProperty, yProperty, zProperty, sProperty);
    }
 
-   public void set(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty,
+   public void set(Property<ReferenceFrameWrapper> referenceFrameProperty,
+                   DoubleProperty xProperty,
+                   DoubleProperty yProperty,
+                   DoubleProperty zProperty,
                    DoubleProperty sProperty)
    {
       set(referenceFrameProperty, xProperty, yProperty, zProperty, sProperty);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/QuaternionProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/QuaternionProperty.java
@@ -3,7 +3,7 @@ package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
-import us.ihmc.euclid.referenceFrame.interfaces.FrameQuaternionReadOnly;
+import us.ihmc.euclid.tuple4D.interfaces.QuaternionReadOnly;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 
 import java.util.Objects;
@@ -11,7 +11,7 @@ import java.util.Objects;
 import static us.ihmc.scs2.definition.yoComposite.YoQuaternionDefinition.YoQuaternion;
 import static us.ihmc.scs2.definition.yoComposite.YoQuaternionDefinition.YoQuaternionIdentifiers;
 
-public class QuaternionProperty extends Orientation3DProperty implements FrameQuaternionReadOnly
+public class QuaternionProperty extends Orientation3DProperty implements QuaternionReadOnly
 {
    public QuaternionProperty()
    {
@@ -105,7 +105,8 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
 
    public void set(ReferenceFrameWrapper referenceFrame, double x, double y, double z, double s)
    {
-      set(referenceFrame, x, y, z, s);
+      setReferenceFrame(referenceFrame);
+      setComponentValues(x, y, z, s);
    }
 
    public void set(DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty, DoubleProperty sProperty)
@@ -119,7 +120,8 @@ public class QuaternionProperty extends Orientation3DProperty implements FrameQu
                    DoubleProperty zProperty,
                    DoubleProperty sProperty)
    {
-      set(referenceFrameProperty, xProperty, yProperty, zProperty, sProperty);
+      setReferenceFrameProperty(referenceFrameProperty);
+      setComponentValueProperties(xProperty, yProperty, zProperty, sProperty);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple2DProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple2DProperty.java
@@ -1,18 +1,18 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
-import static us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition.YoTuple2D;
-import static us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition.YoTuple2DIdentifiers;
-
-import java.util.Objects;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
 import us.ihmc.euclid.interfaces.EuclidGeometry;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameTuple2DReadOnly;
 import us.ihmc.euclid.tuple2D.Point2D;
 import us.ihmc.euclid.tuple2D.Vector2D;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
+
+import java.util.Objects;
+
+import static us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition.YoTuple2D;
+import static us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition.YoTuple2DIdentifiers;
 
 public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DReadOnly
 {
@@ -26,7 +26,7 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
       super(YoTuple2D, YoTuple2DIdentifiers, x, y);
    }
 
-   public Tuple2DProperty(ReferenceFrame referenceFrame, double x, double y)
+   public Tuple2DProperty(ReferenceFrameWrapper referenceFrame, double x, double y)
    {
       super(YoTuple2D, YoTuple2DIdentifiers, referenceFrame, x, y);
    }
@@ -36,7 +36,7 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
       super(YoTuple2D, YoTuple2DIdentifiers, xyProperties);
    }
 
-   public Tuple2DProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty[] xyProperties)
+   public Tuple2DProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty[] xyProperties)
    {
       super(YoTuple2D, YoTuple2DIdentifiers, referenceFrameProperty, xyProperties);
    }
@@ -46,7 +46,7 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
       super(YoTuple2D, YoTuple2DIdentifiers, xProperty, yProperty);
    }
 
-   public Tuple2DProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty)
+   public Tuple2DProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty)
    {
       super(YoTuple2D, YoTuple2DIdentifiers, referenceFrameProperty, xProperty, yProperty);
    }
@@ -82,7 +82,7 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
       setComponentValues(x, y);
    }
 
-   public void set(ReferenceFrame referenceFrame, double x, double y)
+   public void set(ReferenceFrameWrapper referenceFrame, double x, double y)
    {
       set(referenceFrame, x, y);
    }
@@ -92,7 +92,7 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
       setComponentValueProperties(xProperty, yProperty);
    }
 
-   public void set(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty)
+   public void set(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty)
    {
       set(referenceFrameProperty, xProperty, yProperty);
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple2DProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple2DProperty.java
@@ -4,9 +4,9 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
 import us.ihmc.euclid.interfaces.EuclidGeometry;
-import us.ihmc.euclid.referenceFrame.interfaces.FrameTuple2DReadOnly;
 import us.ihmc.euclid.tuple2D.Point2D;
 import us.ihmc.euclid.tuple2D.Vector2D;
+import us.ihmc.euclid.tuple2D.interfaces.Tuple2DReadOnly;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 
 import java.util.Objects;
@@ -14,7 +14,7 @@ import java.util.Objects;
 import static us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition.YoTuple2D;
 import static us.ihmc.scs2.definition.yoComposite.YoTuple2DDefinition.YoTuple2DIdentifiers;
 
-public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DReadOnly
+public class Tuple2DProperty extends CompositeProperty implements Tuple2DReadOnly
 {
    public Tuple2DProperty()
    {
@@ -84,7 +84,8 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
 
    public void set(ReferenceFrameWrapper referenceFrame, double x, double y)
    {
-      set(referenceFrame, x, y);
+      setReferenceFrame(referenceFrame);
+      setComponentValues(x, y);
    }
 
    public void set(DoubleProperty xProperty, DoubleProperty yProperty)
@@ -94,7 +95,8 @@ public class Tuple2DProperty extends CompositeProperty implements FrameTuple2DRe
 
    public void set(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty)
    {
-      set(referenceFrameProperty, xProperty, yProperty);
+      setReferenceFrameProperty(referenceFrameProperty);
+      setComponentValueProperties(xProperty, yProperty);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple3DProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple3DProperty.java
@@ -4,9 +4,9 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
 import us.ihmc.euclid.interfaces.EuclidGeometry;
-import us.ihmc.euclid.referenceFrame.interfaces.FrameTuple3DReadOnly;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.tuple3D.interfaces.Tuple3DReadOnly;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 
 import java.util.Objects;
@@ -14,7 +14,7 @@ import java.util.Objects;
 import static us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition.YoTuple3D;
 import static us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition.YoTuple3DIdentifiers;
 
-public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DReadOnly
+public class Tuple3DProperty extends CompositeProperty implements Tuple3DReadOnly
 {
    public Tuple3DProperty()
    {
@@ -94,7 +94,8 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
 
    public void set(ReferenceFrameWrapper referenceFrame, double x, double y, double z)
    {
-      set(referenceFrame, x, y, z);
+      setReferenceFrame(referenceFrame);
+      setComponentValues(x, y, z);
    }
 
    public void set(DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty)
@@ -104,7 +105,8 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
 
    public void set(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty)
    {
-      set(referenceFrameProperty, xProperty, yProperty, zProperty);
+      setReferenceFrameProperty(referenceFrameProperty);
+      setComponentValueProperties(xProperty, yProperty, zProperty);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple3DProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/Tuple3DProperty.java
@@ -1,18 +1,18 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
-import static us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition.YoTuple3D;
-import static us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition.YoTuple3DIdentifiers;
-
-import java.util.Objects;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
 import us.ihmc.euclid.interfaces.EuclidGeometry;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameTuple3DReadOnly;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
+
+import java.util.Objects;
+
+import static us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition.YoTuple3D;
+import static us.ihmc.scs2.definition.yoComposite.YoTuple3DDefinition.YoTuple3DIdentifiers;
 
 public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DReadOnly
 {
@@ -26,7 +26,7 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
       super(YoTuple3D, YoTuple3DIdentifiers, x, y, z);
    }
 
-   public Tuple3DProperty(ReferenceFrame referenceFrame, double x, double y, double z)
+   public Tuple3DProperty(ReferenceFrameWrapper referenceFrame, double x, double y, double z)
    {
       super(YoTuple3D, YoTuple3DIdentifiers, referenceFrame, x, y, z);
    }
@@ -36,7 +36,7 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
       super(YoTuple3D, YoTuple3DIdentifiers, xyzProperties);
    }
 
-   public Tuple3DProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty[] xyzProperties)
+   public Tuple3DProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty[] xyzProperties)
    {
       super(YoTuple3D, YoTuple3DIdentifiers, referenceFrameProperty, xyzProperties);
    }
@@ -46,7 +46,7 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
       super(YoTuple3D, YoTuple3DIdentifiers, xProperty, yProperty, zProperty);
    }
 
-   public Tuple3DProperty(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty)
+   public Tuple3DProperty(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty)
    {
       super(YoTuple3D, YoTuple3DIdentifiers, referenceFrameProperty, xProperty, yProperty, zProperty);
    }
@@ -92,7 +92,7 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
       setComponentValues(x, y, z);
    }
 
-   public void set(ReferenceFrame referenceFrame, double x, double y, double z)
+   public void set(ReferenceFrameWrapper referenceFrame, double x, double y, double z)
    {
       set(referenceFrame, x, y, z);
    }
@@ -102,7 +102,7 @@ public class Tuple3DProperty extends CompositeProperty implements FrameTuple3DRe
       setComponentValueProperties(xProperty, yProperty, zProperty);
    }
 
-   public void set(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty)
+   public void set(Property<ReferenceFrameWrapper> referenceFrameProperty, DoubleProperty xProperty, DoubleProperty yProperty, DoubleProperty zProperty)
    {
       set(referenceFrameProperty, xProperty, yProperty, zProperty);
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/YawPitchRollProperty.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoComposite/YawPitchRollProperty.java
@@ -1,17 +1,17 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoComposite;
 
-import static us.ihmc.scs2.definition.yoComposite.YoYawPitchRollDefinition.YoYawPitchRoll;
-import static us.ihmc.scs2.definition.yoComposite.YoYawPitchRollDefinition.YoYawPitchRollIdentifiers;
-
-import java.util.Objects;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleDoubleProperty;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.euclid.referenceFrame.interfaces.FrameYawPitchRollReadOnly;
+import us.ihmc.euclid.yawPitchRoll.interfaces.YawPitchRollReadOnly;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 
-public class YawPitchRollProperty extends Orientation3DProperty implements FrameYawPitchRollReadOnly
+import java.util.Objects;
+
+import static us.ihmc.scs2.definition.yoComposite.YoYawPitchRollDefinition.YoYawPitchRoll;
+import static us.ihmc.scs2.definition.yoComposite.YoYawPitchRollDefinition.YoYawPitchRollIdentifiers;
+
+public class YawPitchRollProperty extends Orientation3DProperty implements YawPitchRollReadOnly
 {
    public YawPitchRollProperty()
    {
@@ -23,7 +23,7 @@ public class YawPitchRollProperty extends Orientation3DProperty implements Frame
       super(YoYawPitchRoll, YoYawPitchRollIdentifiers, yaw, pitch, roll);
    }
 
-   public YawPitchRollProperty(ReferenceFrame referenceFrame, double yaw, double pitch, double roll)
+   public YawPitchRollProperty(ReferenceFrameWrapper referenceFrame, double yaw, double pitch, double roll)
    {
       super(YoYawPitchRoll, YoYawPitchRollIdentifiers, referenceFrame, yaw, pitch, roll);
    }
@@ -33,7 +33,7 @@ public class YawPitchRollProperty extends Orientation3DProperty implements Frame
       super(YoYawPitchRoll, YoYawPitchRollIdentifiers, yawPitchRollProperties);
    }
 
-   public YawPitchRollProperty(Property<ReferenceFrame> referenceFrame, DoubleProperty[] yawPitchRollProperties)
+   public YawPitchRollProperty(Property<ReferenceFrameWrapper> referenceFrame, DoubleProperty[] yawPitchRollProperties)
    {
       super(YoYawPitchRoll, YoYawPitchRollIdentifiers, referenceFrame, yawPitchRollProperties);
    }
@@ -43,8 +43,10 @@ public class YawPitchRollProperty extends Orientation3DProperty implements Frame
       super(YoYawPitchRoll, YoYawPitchRollIdentifiers, yawProperty, pitchProperty, rollProperty);
    }
 
-   public YawPitchRollProperty(DoubleProperty yawProperty, DoubleProperty pitchProperty, DoubleProperty rollProperty,
-                                     Property<ReferenceFrame> referenceFrameProperty)
+   public YawPitchRollProperty(Property<ReferenceFrameWrapper> referenceFrameProperty,
+                               DoubleProperty yawProperty,
+                               DoubleProperty pitchProperty,
+                               DoubleProperty rollProperty)
    {
       super(YoYawPitchRoll, YoYawPitchRollIdentifiers, referenceFrameProperty, yawProperty, pitchProperty, rollProperty);
    }
@@ -90,19 +92,9 @@ public class YawPitchRollProperty extends Orientation3DProperty implements Frame
       setComponentValues(yaw, pitch, roll);
    }
 
-   public void set(ReferenceFrame referenceFrame, double yaw, double pitch, double roll)
-   {
-      set(referenceFrame, yaw, pitch, roll);
-   }
-
    public void set(DoubleProperty yawProperty, DoubleProperty pitchProperty, DoubleProperty rollProperty)
    {
       setComponentValueProperties(yawProperty, pitchProperty, rollProperty);
-   }
-
-   public void set(Property<ReferenceFrame> referenceFrameProperty, DoubleProperty yawProperty, DoubleProperty pitchProperty, DoubleProperty rollProperty)
-   {
-      set(referenceFrameProperty, yawProperty, pitchProperty, rollProperty);
    }
 
    @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoArrowFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoArrowFX3D.java
@@ -13,10 +13,10 @@ import javafx.scene.transform.Scale;
 import javafx.scene.transform.Translate;
 import us.ihmc.euclid.axisAngle.AxisAngle;
 import us.ihmc.euclid.geometry.tools.EuclidGeometryTools;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
 import us.ihmc.scs2.definition.geometry.Cone3DDefinition;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 
@@ -55,7 +55,7 @@ public class YoArrowFX3D extends YoGraphicFX3D
       arrow.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoArrowFX3D(ReferenceFrame worldFrame)
+   public YoArrowFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       origin.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoBoxFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoBoxFX3D.java
@@ -4,7 +4,7 @@ import javafx.scene.Node;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Box;
 import javafx.scene.transform.Affine;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
@@ -30,7 +30,7 @@ public class YoBoxFX3D extends YoGraphicFX3D
       boxNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoBoxFX3D(ReferenceFrame worldFrame)
+   public YoBoxFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoCapsuleFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoCapsuleFX3D.java
@@ -10,11 +10,11 @@ import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
 import us.ihmc.euclid.axisAngle.AxisAngle;
 import us.ihmc.euclid.geometry.tools.EuclidGeometryTools;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tools.EuclidCoreTools;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DFactories;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
@@ -44,7 +44,7 @@ public class YoCapsuleFX3D extends YoGraphicFX3D
       capsuleNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoCapsuleFX3D(ReferenceFrame worldFrame)
+   public YoCapsuleFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       center.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoConeFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoConeFX3D.java
@@ -10,11 +10,11 @@ import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
 import us.ihmc.euclid.axisAngle.AxisAngle;
 import us.ihmc.euclid.geometry.tools.EuclidGeometryTools;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tools.EuclidCoreTools;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DFactories;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
@@ -44,7 +44,7 @@ public class YoConeFX3D extends YoGraphicFX3D
       coneNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoConeFX3D(ReferenceFrame worldFrame)
+   public YoConeFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoConvexPolytopeFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoConvexPolytopeFX3D.java
@@ -1,8 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleIntegerProperty;
@@ -12,17 +9,20 @@ import javafx.scene.shape.Mesh;
 import javafx.scene.shape.MeshView;
 import javafx.scene.transform.Affine;
 import us.ihmc.euclid.geometry.interfaces.Vertex3DSupplier;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.shape.convexPolytope.ConvexPolytope3D;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.tuple3D.interfaces.Point3DReadOnly;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DFactories;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class YoConvexPolytopeFX3D extends YoGraphicFX3D
 {
@@ -48,7 +48,7 @@ public class YoConvexPolytopeFX3D extends YoGraphicFX3D
       polytopeNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoConvexPolytopeFX3D(ReferenceFrame worldFrame)
+   public YoConvexPolytopeFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);
@@ -153,7 +153,8 @@ public class YoConvexPolytopeFX3D extends YoGraphicFX3D
 
       List<Point3DReadOnly> vertices = newDataLocal.vertices;
 
-      newMesh = JavaFXTriangleMesh3DDefinitionInterpreter.interpretDefinition(TriangleMesh3DFactories.ConvexPolytope(new ConvexPolytope3D(Vertex3DSupplier.asVertex3DSupplier(vertices))));
+      newMesh = JavaFXTriangleMesh3DDefinitionInterpreter.interpretDefinition(TriangleMesh3DFactories.ConvexPolytope(new ConvexPolytope3D(Vertex3DSupplier.asVertex3DSupplier(
+            vertices))));
       oldData = newDataLocal;
    }
 

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoCoordinateSystemFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoCoordinateSystemFX3D.java
@@ -15,10 +15,10 @@ import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
 import us.ihmc.euclid.Axis3D;
 import us.ihmc.euclid.axisAngle.AxisAngle;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DBuilder;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXVisualTools;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
@@ -53,7 +53,7 @@ public class YoCoordinateSystemFX3D extends YoGraphicFX3D
       coordinateSystemNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoCoordinateSystemFX3D(ReferenceFrame worldFrame)
+   public YoCoordinateSystemFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoCylinderFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoCylinderFX3D.java
@@ -10,11 +10,11 @@ import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
 import us.ihmc.euclid.axisAngle.AxisAngle;
 import us.ihmc.euclid.geometry.tools.EuclidGeometryTools;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tools.EuclidCoreTools;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DFactories;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
@@ -44,7 +44,7 @@ public class YoCylinderFX3D extends YoGraphicFX3D
       cylinderNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoCylinderFX3D(ReferenceFrame worldFrame)
+   public YoCylinderFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       center.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoEllipsoidFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoEllipsoidFX3D.java
@@ -4,7 +4,7 @@ import javafx.scene.Node;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Sphere;
 import javafx.scene.transform.Affine;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
@@ -29,7 +29,7 @@ public class YoEllipsoidFX3D extends YoGraphicFX3D
       ellipsoidNode.idProperty().bind(nameProperty());
    }
 
-   public YoEllipsoidFX3D(ReferenceFrame worldFrame)
+   public YoEllipsoidFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoGraphicTools.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoGraphicTools.java
@@ -1,12 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.scene.Group;
@@ -47,33 +40,11 @@ import us.ihmc.scs2.definition.visual.PaintDefinition;
 import us.ihmc.scs2.definition.yoComposite.YoColorRGBADoubleDefinition;
 import us.ihmc.scs2.definition.yoComposite.YoColorRGBAIntDefinition;
 import us.ihmc.scs2.definition.yoComposite.YoColorRGBASingleDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphic2DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphic3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicArrow3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicBox3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicCapsule3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicCone3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicConvexPolytope3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicCoordinateSystem3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicCylinder3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicEllipsoid3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicGroupDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicLine2DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicListDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPoint2DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPoint3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPointcloud2DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPointcloud3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPolygon2DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPolygonExtruded3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicPolynomial3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicRamp3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoGraphicSTPBox3DDefinition;
-import us.ihmc.scs2.definition.yoGraphic.YoListDefinition;
+import us.ihmc.scs2.definition.yoGraphic.*;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic.YoGraphicFXControllerTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXVisualTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.CompositePropertyTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.YoVariableDatabase;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
@@ -84,6 +55,13 @@ import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.YoColorRGBADoubleFX;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.YoColorRGBAIntFX;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.YoColorRGBASingleFX;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class YoGraphicTools
 {
@@ -261,8 +239,8 @@ public class YoGraphicTools
       else if (yoGraphicFX instanceof YoGraphicFX3D)
          isValidName = !parentGroup.containsYoGraphicFX3D(yoGraphicFX.getName());
       else
-         throw new RuntimeException("The following " + YoGraphicFX.class.getSimpleName() + " has unexpected hierarchy "
-                                    + yoGraphicFX.getClass().getSimpleName());
+         throw new RuntimeException(
+               "The following " + YoGraphicFX.class.getSimpleName() + " has unexpected hierarchy " + yoGraphicFX.getClass().getSimpleName());
 
       if (!isValidName)
          yoGraphicFX.setName(YoGraphicFXControllerTools.createAvailableYoGraphicFXItemName(parentGroup, yoGraphicFX.getName(), yoGraphicFX.getClass()));
@@ -890,13 +868,18 @@ public class YoGraphicTools
       return new SimpleColorFX(JavaFXVisualTools.toColor(definition));
    }
 
-   public static YoGroupFX convertRobotCollisionShapeDefinitions(RigidBodyReadOnly rootBody, RobotDefinition robotDefinition)
+   public static YoGroupFX convertRobotCollisionShapeDefinitions(RigidBodyReadOnly rootBody,
+                                                                 RobotDefinition robotDefinition,
+                                                                 ReferenceFrameManager referenceFrameManager)
    {
       Color color = Color.AQUAMARINE.deriveColor(0.0, 1.0, 1.0, 0.4); // Transparent aquamarine
-      return convertRobotCollisionShapeDefinitions(rootBody, robotDefinition, color);
+      return convertRobotCollisionShapeDefinitions(rootBody, robotDefinition, referenceFrameManager, color);
    }
 
-   public static YoGroupFX convertRobotCollisionShapeDefinitions(RigidBodyReadOnly rootBody, RobotDefinition robotDefinition, Color color)
+   public static YoGroupFX convertRobotCollisionShapeDefinitions(RigidBodyReadOnly rootBody,
+                                                                 RobotDefinition robotDefinition,
+                                                                 ReferenceFrameManager referenceFrameManager,
+                                                                 Color color)
    {
       YoGroupFX robotCollisionGroup = new YoGroupFX(robotDefinition.getName());
 
@@ -910,7 +893,8 @@ public class YoGraphicTools
             continue;
 
          RigidBodyReadOnly rigidBody = MultiBodySystemTools.findRigidBody(rootBody, rigidBodyDefinition.getName());
-         ReferenceFrame referenceFrame = rigidBody.isRootBody() ? rigidBody.getBodyFixedFrame() : rigidBody.getParentJoint().getFrameAfterJoint();
+         ReferenceFrame robotFrame = rigidBody.isRootBody() ? rigidBody.getBodyFixedFrame() : rigidBody.getParentJoint().getFrameAfterJoint();
+         ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(robotFrame.getName());
          YoGroupFX collisionGroup = convertRigidBodyCollisionShapeDefinitions(referenceFrame, rigidBodyDefinition, color);
 
          if (collisionGroup != null)
@@ -920,7 +904,7 @@ public class YoGraphicTools
       return robotCollisionGroup;
    }
 
-   public static YoGroupFX convertRigidBodyCollisionShapeDefinitions(ReferenceFrame referenceFrame, RigidBodyDefinition rigidBodyDefinition, Color color)
+   public static YoGroupFX convertRigidBodyCollisionShapeDefinitions(ReferenceFrameWrapper referenceFrame, RigidBodyDefinition rigidBodyDefinition, Color color)
    {
       List<CollisionShapeDefinition> collisionShapeDefinitions = rigidBodyDefinition.getCollisionShapeDefinitions();
 
@@ -957,13 +941,14 @@ public class YoGraphicTools
       return yoGroupFX;
    }
 
-   public static YoGroupFX convertTerrainObjectsCollisionShapeDefinitions(ReferenceFrame worldFrame, List<TerrainObjectDefinition> terrainObjectDefinitions)
+   public static YoGroupFX convertTerrainObjectsCollisionShapeDefinitions(ReferenceFrameWrapper worldFrame,
+                                                                          List<TerrainObjectDefinition> terrainObjectDefinitions)
    {
       Color color = Color.BLUEVIOLET.deriveColor(0.0, 1.0, 1.0, 0.4); // Transparent blueviolet
       return convertTerrainObjectsCollisionShapeDefinitions(worldFrame, terrainObjectDefinitions, color);
    }
 
-   public static YoGroupFX convertTerrainObjectsCollisionShapeDefinitions(ReferenceFrame worldFrame,
+   public static YoGroupFX convertTerrainObjectsCollisionShapeDefinitions(ReferenceFrameWrapper worldFrame,
                                                                           List<TerrainObjectDefinition> terrainObjectDefinitions,
                                                                           Color color)
    {
@@ -984,7 +969,7 @@ public class YoGraphicTools
       return terrainsCollisionGroup;
    }
 
-   public static YoGroupFX convertTerrainObjectCollisionShapeDefinitions(ReferenceFrame worldFrame,
+   public static YoGroupFX convertTerrainObjectCollisionShapeDefinitions(ReferenceFrameWrapper worldFrame,
                                                                          TerrainObjectDefinition terrainObjectDefinition,
                                                                          Color color)
    {
@@ -1027,12 +1012,12 @@ public class YoGraphicTools
       return yoGroupFX;
    }
 
-   public static YoGraphicFX3D convertCollisionShapeDefinition(ReferenceFrame referenceFrame, CollisionShapeDefinition collisionShapeDefinition)
+   public static YoGraphicFX3D convertCollisionShapeDefinition(ReferenceFrameWrapper referenceFrame, CollisionShapeDefinition collisionShapeDefinition)
    {
       return convertGeometryDefinition(referenceFrame, collisionShapeDefinition.getOriginPose(), collisionShapeDefinition.getGeometryDefinition());
    }
 
-   public static YoGraphicFX3D convertGeometryDefinition(ReferenceFrame referenceFrame,
+   public static YoGraphicFX3D convertGeometryDefinition(ReferenceFrameWrapper referenceFrame,
                                                          RigidBodyTransformReadOnly originPose,
                                                          GeometryDefinition geometryDefinition)
    {
@@ -1059,17 +1044,22 @@ public class YoGraphicTools
       else if (geometryDefinition instanceof Sphere3DDefinition)
          return convertSphere3DDefinition(referenceFrame, originPose, (Sphere3DDefinition) geometryDefinition);
       else
-         throw new UnsupportedOperationException("Unsupported " + GeometryDefinition.class.getSimpleName() + ": "
-                                                 + geometryDefinition.getClass().getSimpleName());
+         throw new UnsupportedOperationException(
+               "Unsupported " + GeometryDefinition.class.getSimpleName() + ": " + geometryDefinition.getClass().getSimpleName());
    }
 
-   public static YoGroupFX convertRobotMassPropertiesShapeDefinitions(RigidBodyReadOnly rootBody, RobotDefinition robotDefinition)
+   public static YoGroupFX convertRobotMassPropertiesShapeDefinitions(RigidBodyReadOnly rootBody,
+                                                                      RobotDefinition robotDefinition,
+                                                                      ReferenceFrameManager referenceFrameManager)
    {
       Color color = Color.DARKSEAGREEN.deriveColor(0.0, 1.0, 1.0, 0.4); // Transparent
-      return convertRobotMassPropertiesShapeDefinitions(rootBody, robotDefinition, color);
+      return convertRobotMassPropertiesShapeDefinitions(rootBody, robotDefinition, referenceFrameManager, color);
    }
 
-   public static YoGroupFX convertRobotMassPropertiesShapeDefinitions(RigidBodyReadOnly rootBody, RobotDefinition robotDefinition, Color color)
+   public static YoGroupFX convertRobotMassPropertiesShapeDefinitions(RigidBodyReadOnly rootBody,
+                                                                      RobotDefinition robotDefinition,
+                                                                      ReferenceFrameManager referenceFrameManager,
+                                                                      Color color)
    {
       YoGroupFX robotMassPropertiesGroup = new YoGroupFX(robotDefinition.getName());
 
@@ -1091,7 +1081,9 @@ public class YoGraphicTools
          if (rigidBody.isRootBody())
             continue;
 
-         ReferenceFrame referenceFrame = rigidBody.getParentJoint().getFrameAfterJoint();
+         ReferenceFrameWrapper referenceFrame = referenceFrameManager.getReferenceFrameFromFullname(rigidBody.getParentJoint()
+                                                                                                             .getFrameAfterJoint()
+                                                                                                             .getNameId());
 
          RigidBodyTransform ellipsoidPose = new RigidBodyTransform(rigidBodyDefinition.getInertiaPose());
          ellipsoidPose.appendOrientation(svd.getU());
@@ -1108,7 +1100,7 @@ public class YoGraphicTools
    /**
     * Returns the radii of an ellipsoid given the inertia parameters, assuming a uniform mass
     * distribution.
-    * 
+    *
     * @param principalMomentsOfInertia principal moments of inertia {Ixx, Iyy, Izz}
     * @param mass                      mass of the link
     * @return the three radii of the inertia ellipsoid
@@ -1128,7 +1120,9 @@ public class YoGraphicTools
       return radii;
    }
 
-   public static YoBoxFX3D convertBox3DDefinition(ReferenceFrame referenceFrame, RigidBodyTransformReadOnly originPose, Box3DDefinition geometryDefinition)
+   public static YoBoxFX3D convertBox3DDefinition(ReferenceFrameWrapper referenceFrame,
+                                                  RigidBodyTransformReadOnly originPose,
+                                                  Box3DDefinition geometryDefinition)
    {
       YoBoxFX3D yoGraphicFX = new YoBoxFX3D();
       if (!geometryDefinition.isCentered())
@@ -1146,7 +1140,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoSTPBoxFX3D convertSTPBox3DDefinition(ReferenceFrame referenceFrame,
+   public static YoSTPBoxFX3D convertSTPBox3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                         RigidBodyTransformReadOnly originPose,
                                                         STPBox3DDefinition geometryDefinition)
    {
@@ -1161,7 +1155,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoCapsuleFX3D convertCapsule3DDefinition(ReferenceFrame referenceFrame,
+   public static YoCapsuleFX3D convertCapsule3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                           RigidBodyTransformReadOnly originPose,
                                                           Capsule3DDefinition geometryDefinition)
    {
@@ -1179,7 +1173,9 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoConeFX3D convertCone3DDefinition(ReferenceFrame referenceFrame, RigidBodyTransformReadOnly originPose, Cone3DDefinition geometryDefinition)
+   public static YoConeFX3D convertCone3DDefinition(ReferenceFrameWrapper referenceFrame,
+                                                    RigidBodyTransformReadOnly originPose,
+                                                    Cone3DDefinition geometryDefinition)
    {
       YoConeFX3D yoGraphicFX = new YoConeFX3D();
       Tuple3DReadOnly position = originPose.getTranslation();
@@ -1192,7 +1188,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoCylinderFX3D convertCylinder3DDefinition(ReferenceFrame referenceFrame,
+   public static YoCylinderFX3D convertCylinder3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                             RigidBodyTransformReadOnly originPose,
                                                             Cylinder3DDefinition geometryDefinition)
    {
@@ -1210,7 +1206,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoEllipsoidFX3D convertEllipsoid3DDefinition(ReferenceFrame referenceFrame,
+   public static YoEllipsoidFX3D convertEllipsoid3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                               RigidBodyTransformReadOnly originPose,
                                                               Ellipsoid3DDefinition geometryDefinition)
    {
@@ -1226,7 +1222,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoPolygonExtrudedFX3D convertExtrudedPolygon2DDefinition(ReferenceFrame referenceFrame,
+   public static YoPolygonExtrudedFX3D convertExtrudedPolygon2DDefinition(ReferenceFrameWrapper referenceFrame,
                                                                           RigidBodyTransformReadOnly originPose,
                                                                           ExtrudedPolygon2DDefinition geometryDefinition)
    {
@@ -1247,7 +1243,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoConvexPolytopeFX3D convertConvexPolytope3DDefinition(ReferenceFrame referenceFrame,
+   public static YoConvexPolytopeFX3D convertConvexPolytope3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                                         RigidBodyTransformReadOnly originPose,
                                                                         ConvexPolytope3DDefinition geometryDefinition)
    {
@@ -1265,7 +1261,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoPointFX3D convertPoint3DDefinition(ReferenceFrame referenceFrame,
+   public static YoPointFX3D convertPoint3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                       RigidBodyTransformReadOnly originPose,
                                                       Point3DDefinition geometryDefinition)
    {
@@ -1276,7 +1272,7 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoPointFX3D convertSphere3DDefinition(ReferenceFrame referenceFrame,
+   public static YoPointFX3D convertSphere3DDefinition(ReferenceFrameWrapper referenceFrame,
                                                        RigidBodyTransformReadOnly originPose,
                                                        Sphere3DDefinition geometryDefinition)
    {
@@ -1287,7 +1283,9 @@ public class YoGraphicTools
       return yoGraphicFX;
    }
 
-   public static YoRampFX3D convertRamp3DDefinition(ReferenceFrame referenceFrame, RigidBodyTransformReadOnly originPose, Ramp3DDefinition geometryDefinition)
+   public static YoRampFX3D convertRamp3DDefinition(ReferenceFrameWrapper referenceFrame,
+                                                    RigidBodyTransformReadOnly originPose,
+                                                    Ramp3DDefinition geometryDefinition)
    {
       YoRampFX3D yoGraphicFX = new YoRampFX3D();
       Tuple3DReadOnly position = originPose.getTranslation();

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoLineFX2D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoLineFX2D.java
@@ -2,9 +2,9 @@ package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
 import javafx.scene.Node;
 import javafx.scene.shape.Line;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple2D.Point2D;
 import us.ihmc.euclid.tuple2D.Vector2D;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple2DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
 
@@ -22,7 +22,7 @@ public class YoLineFX2D extends YoGraphicFX2D
       lineNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoLineFX2D(ReferenceFrame worldFrame)
+   public YoLineFX2D(ReferenceFrameWrapper worldFrame)
    {
       this();
       origin.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPointFX2D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPointFX2D.java
@@ -1,7 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
-import java.util.List;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleDoubleProperty;
@@ -16,9 +14,11 @@ import javafx.scene.transform.Scale;
 import javafx.scene.transform.Translate;
 import net.javainthebox.caraibe.svg.SVGContent;
 import net.javainthebox.caraibe.svg.SVGLoader;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple2D.Point2D;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple2DProperty;
+
+import java.util.List;
 
 public class YoPointFX2D extends YoGraphicFX2D
 {
@@ -41,7 +41,7 @@ public class YoPointFX2D extends YoGraphicFX2D
       setGraphicResource(YoGraphicFXResourceManager.DEFAULT_POINT2D_GRAPHIC_RESOURCE);
    }
 
-   public YoPointFX2D(ReferenceFrame worldFrame)
+   public YoPointFX2D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);
@@ -73,7 +73,6 @@ public class YoPointFX2D extends YoGraphicFX2D
          shape.strokeWidthProperty().bind(strokeWidthProperty);
          shape.idProperty().bind(nameProperty());
       }
-
    }
 
    @Override
@@ -85,10 +84,10 @@ public class YoPointFX2D extends YoGraphicFX2D
       if (position.containsNaN())
       {
          pointNode.getChildren().clear();
-//         translate.setX(Double.NEGATIVE_INFINITY);
-//         translate.setY(Double.NEGATIVE_INFINITY);
-//         scale.setX(0.0);
-//         scale.setY(0.0);
+         //         translate.setX(Double.NEGATIVE_INFINITY);
+         //         translate.setY(Double.NEGATIVE_INFINITY);
+         //         scale.setX(0.0);
+         //         scale.setY(0.0);
          return;
       }
       else

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPointFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPointFX3D.java
@@ -1,8 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
-import java.util.Arrays;
-import java.util.List;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Group;
@@ -11,10 +8,13 @@ import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Shape3D;
 import javafx.scene.transform.Scale;
 import javafx.scene.transform.Translate;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXVisualTools;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class YoPointFX3D extends YoGraphicFX3D
 {
@@ -35,7 +35,7 @@ public class YoPointFX3D extends YoGraphicFX3D
       pointNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoPointFX3D(ReferenceFrame worldFrame)
+   public YoPointFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPolygonExtrudedFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPolygonExtrudedFX3D.java
@@ -1,10 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleDoubleProperty;
@@ -14,18 +9,23 @@ import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Mesh;
 import javafx.scene.shape.MeshView;
 import javafx.scene.transform.Affine;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple2D.Point2D;
 import us.ihmc.euclid.tuple2D.Vector2D;
 import us.ihmc.euclid.tuple2D.interfaces.Point2DReadOnly;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DFactories;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple2DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Tuple3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic.color.SimpleColorFX;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class YoPolygonExtrudedFX3D extends YoGraphicFX3D
 {
@@ -52,7 +52,7 @@ public class YoPolygonExtrudedFX3D extends YoGraphicFX3D
       polygonNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoPolygonExtrudedFX3D(ReferenceFrame worldFrame)
+   public YoPolygonExtrudedFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPolynomialFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoPolynomialFX3D.java
@@ -1,11 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoGraphic;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.function.DoubleConsumer;
-import java.util.stream.Stream;
-
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.Property;
@@ -24,13 +18,20 @@ import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.scs2.definition.visual.SegmentedLine3DTriangleMeshFactory;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.DoubleConsumer;
+import java.util.stream.Stream;
 
 public class YoPolynomialFX3D extends YoGraphicFX3D
 {
    private List<DoubleProperty> coefficientsX, coefficientsY, coefficientsZ;
    private IntegerProperty numberOfCoefficientsX, numberOfCoefficientsY, numberOfCoefficientsZ;
-   private Property<ReferenceFrame> referenceFrame;
+   private Property<ReferenceFrameWrapper> referenceFrame;
    private DoubleProperty startTime = new SimpleDoubleProperty(0.0);
    private DoubleProperty endTime;
    private DoubleProperty size = new SimpleDoubleProperty(0.01);
@@ -113,8 +114,8 @@ public class YoPolynomialFX3D extends YoGraphicFX3D
          return;
       }
       else if (newPolynomialLocal.coefficientsX == null || newPolynomialLocal.coefficientsY == null || newPolynomialLocal.coefficientsZ == null
-            || newPolynomialLocal.coefficientsX.length == 0 || newPolynomialLocal.coefficientsY.length == 0 || newPolynomialLocal.coefficientsZ.length == 0
-            || newPolynomialLocal.containsNaN())
+               || newPolynomialLocal.coefficientsX.length == 0 || newPolynomialLocal.coefficientsY.length == 0 || newPolynomialLocal.coefficientsZ.length == 0
+               || newPolynomialLocal.containsNaN())
       {
          newMeshViews = new MeshView[0];
          return;
@@ -314,12 +315,12 @@ public class YoPolynomialFX3D extends YoGraphicFX3D
       setNumberOfCoefficientsZ(new SimpleIntegerProperty(numberOfCoefficientsZ));
    }
 
-   public void setReferenceFrame(ReferenceFrame referenceFrame)
+   public void setReferenceFrame(ReferenceFrameWrapper referenceFrame)
    {
       setReferenceFrame(new SimpleObjectProperty<>(referenceFrame));
    }
 
-   public void setReferenceFrame(Property<ReferenceFrame> referenceFrame)
+   public void setReferenceFrame(Property<ReferenceFrameWrapper> referenceFrame)
    {
       this.referenceFrame = referenceFrame;
    }
@@ -441,7 +442,7 @@ public class YoPolynomialFX3D extends YoGraphicFX3D
       return numberOfCoefficientsZ;
    }
 
-   public Property<ReferenceFrame> getReferenceFrame()
+   public Property<ReferenceFrameWrapper> getReferenceFrame()
    {
       return referenceFrame;
    }

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoRampFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoRampFX3D.java
@@ -5,9 +5,9 @@ import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.MeshView;
 import javafx.scene.transform.Affine;
 import javafx.scene.transform.Scale;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.scs2.definition.geometry.Ramp3DDefinition;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
@@ -34,7 +34,7 @@ public class YoRampFX3D extends YoGraphicFX3D
       rampNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoRampFX3D(ReferenceFrame worldFrame)
+   public YoRampFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoSTPBoxFX3D.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoGraphic/YoSTPBoxFX3D.java
@@ -7,11 +7,11 @@ import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Mesh;
 import javafx.scene.shape.MeshView;
 import javafx.scene.transform.Affine;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
 import us.ihmc.scs2.definition.visual.TriangleMesh3DFactories;
 import us.ihmc.scs2.sessionVisualizer.jfx.definition.JavaFXTriangleMesh3DDefinitionInterpreter;
+import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameWrapper;
 import us.ihmc.scs2.sessionVisualizer.jfx.tools.JavaFXMissingTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.Orientation3DProperty;
 import us.ihmc.scs2.sessionVisualizer.jfx.yoComposite.QuaternionProperty;
@@ -45,7 +45,7 @@ public class YoSTPBoxFX3D extends YoGraphicFX3D
       boxNode.getProperties().put(YO_GRAPHICFX_ITEM_KEY, this);
    }
 
-   public YoSTPBoxFX3D(ReferenceFrame worldFrame)
+   public YoSTPBoxFX3D(ReferenceFrameWrapper worldFrame)
    {
       this();
       position.setReferenceFrame(worldFrame);

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoRobot/YoRobotFX.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/yoRobot/YoRobotFX.java
@@ -1,8 +1,5 @@
 package us.ihmc.scs2.sessionVisualizer.jfx.yoRobot;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
-
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
@@ -34,6 +31,9 @@ import us.ihmc.yoVariables.euclid.referenceFrame.YoFramePoseUsingYawPitchRoll;
 import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoDouble;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+
 public class YoRobotFX
 {
    private final Group rootNode = new Group();
@@ -61,7 +61,7 @@ public class YoRobotFX
       LogTools.info("Loading robot: " + robotDefinition.getName());
 
       YoRegistry rootRegistry = new YoRegistry(SimulationSession.ROOT_REGISTRY_NAME);
-      Robot robot = new Robot(robotDefinition, referenceFrameManager.getWorldFrame(), false);
+      Robot robot = new Robot(robotDefinition, referenceFrameManager.getWorldFrame().getReferenceFrame(), false);
       robotRegistry = robot.getRegistry();
       rootRegistry.addChild(robotRegistry);
       rootBody = robot.getRootBody();
@@ -104,12 +104,12 @@ public class YoRobotFX
    {
       robotLinkedYoRegistry = yoManager.newLinkedYoRegistry(robotRegistry);
       robotRegistry.getVariables().forEach(var ->
-      {
-         if (var.getName().startsWith("q_"))
-         { // Only link the YoVariables for the joint angles and root joint configuration.
-            robotLinkedYoRegistry.linkYoVariable(var, this);
-         }
-      });
+                                           {
+                                              if (var.getName().startsWith("q_"))
+                                              { // Only link the YoVariables for the joint angles and root joint configuration.
+                                                 robotLinkedYoRegistry.linkYoVariable(var, this);
+                                              }
+                                           });
 
       for (SimRigidBodyBasics rigidBody : rootBody.subtreeIterable())
       {

--- a/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/SimpleColorEditorPane.fxml
+++ b/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/SimpleColorEditorPane.fxml
@@ -7,22 +7,22 @@
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
-
-<GridPane fx:id="mainPane" styleClass="graphic-editor-gridpane" stylesheets="@../../../css/GeneralStylesheet.css" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1">
-   <columnConstraints>
-      <ColumnConstraints hgrow="NEVER" minWidth="-Infinity" />
-      <ColumnConstraints hgrow="ALWAYS" />
-      <ColumnConstraints hgrow="NEVER" />
-   </columnConstraints>
-   <rowConstraints>
-      <RowConstraints vgrow="SOMETIMES" />
-      <RowConstraints vgrow="SOMETIMES" />
-   </rowConstraints>
-   <children>
-      <Label fx:id="colorLabel" text="Color" />
-      <JFXColorPicker fx:id="colorPicker" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.columnSpan="2147483647" />
-      <Label fx:id="opacityLabel" text="Opacity" GridPane.rowIndex="1" />
-      <JFXSlider fx:id="opacitySlider" majorTickUnit="10.0" minorTickCount="9" value="100.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-      <JFXTextField fx:id="opacityTextField" prefWidth="30.0" text="100" GridPane.columnIndex="2" GridPane.rowIndex="1" />
-   </children>
+<GridPane fx:id="mainPane" styleClass="graphic-editor-gridpane" stylesheets="@../../css/GeneralStylesheet.css" xmlns="http://javafx.com/javafx/15.0.1"
+          xmlns:fx="http://javafx.com/fxml/1">
+    <columnConstraints>
+        <ColumnConstraints hgrow="NEVER" minWidth="-Infinity"/>
+        <ColumnConstraints hgrow="ALWAYS"/>
+        <ColumnConstraints hgrow="NEVER"/>
+    </columnConstraints>
+    <rowConstraints>
+        <RowConstraints vgrow="SOMETIMES"/>
+        <RowConstraints vgrow="SOMETIMES"/>
+    </rowConstraints>
+    <children>
+        <Label fx:id="colorLabel" text="Color"/>
+        <JFXColorPicker fx:id="colorPicker" maxWidth="1.7976931348623157E308" GridPane.columnIndex="1" GridPane.columnSpan="2147483647"/>
+        <Label fx:id="opacityLabel" text="Opacity" GridPane.rowIndex="1"/>
+        <JFXSlider fx:id="opacitySlider" majorTickUnit="10.0" minorTickCount="9" value="100.0" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+        <JFXTextField fx:id="opacityTextField" prefWidth="30.0" text="100" GridPane.columnIndex="2" GridPane.rowIndex="1"/>
+    </children>
 </GridPane>

--- a/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/YoColorRGBAEditorPane.fxml
+++ b/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/YoColorRGBAEditorPane.fxml
@@ -4,50 +4,50 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.RowConstraints?>
-
+<?import javafx.scene.layout.*?>
 <GridPane fx:id="mainPane" hgap="5.0" vgap="5.0" xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/15.0.1">
-   <columnConstraints>
-      <ColumnConstraints hgrow="NEVER" />
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" />
-      <ColumnConstraints hgrow="NEVER" />
-   </columnConstraints>
-   <rowConstraints>
-      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-      <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-   </rowConstraints>
-   <children>
-      <Label fx:id="searchRedLabel" text="Red" />
-      <JFXTextField fx:id="searchRedTextField" GridPane.columnIndex="1" />
-      <ImageView fx:id="redValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2">
-         <image>
-            <Image url="@../../../icons/invalid-icon.png" />
-         </image>
-      </ImageView>
-      <Label fx:id="searchGreenLabel" text="Green" GridPane.rowIndex="1" />
-      <JFXTextField fx:id="searchGreenTextField" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-      <ImageView fx:id="greenValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2" GridPane.rowIndex="1">
-         <image>
-            <Image url="@../../../icons/invalid-icon.png" />
-         </image>
-      </ImageView>
-      <Label fx:id="searchBlueLabel" text="Blue" GridPane.rowIndex="2" />
-      <JFXTextField fx:id="searchBlueTextField" GridPane.columnIndex="1" GridPane.rowIndex="2" />
-      <ImageView fx:id="blueValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2" GridPane.rowIndex="2">
-         <image>
-            <Image url="@../../../icons/invalid-icon.png" />
-         </image>
-      </ImageView>
-      <Label fx:id="searchAlphaLabel" text="Alpha" GridPane.rowIndex="3" />
-      <JFXTextField fx:id="searchAlphaTextField" GridPane.columnIndex="1" GridPane.rowIndex="3" />
-      <ImageView fx:id="alphaValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2" GridPane.rowIndex="3">
-         <image>
-            <Image url="@../../../icons/invalid-icon.png" />
-         </image>
-      </ImageView>
-   </children>
+    <columnConstraints>
+        <ColumnConstraints hgrow="NEVER"/>
+        <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0"/>
+        <ColumnConstraints hgrow="NEVER"/>
+    </columnConstraints>
+    <rowConstraints>
+        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+        <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES"/>
+    </rowConstraints>
+    <children>
+        <Label fx:id="searchRedLabel" text="Red"/>
+        <JFXTextField fx:id="searchRedTextField" GridPane.columnIndex="1"/>
+        <ImageView fx:id="redValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2">
+            <image>
+                <Image url="@../../icons/invalid-icon.png"/>
+            </image>
+        </ImageView>
+        <Label fx:id="searchGreenLabel" text="Green" GridPane.rowIndex="1"/>
+        <JFXTextField fx:id="searchGreenTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+        <ImageView fx:id="greenValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2"
+                   GridPane.rowIndex="1">
+            <image>
+                <Image url="@../../icons/invalid-icon.png"/>
+            </image>
+        </ImageView>
+        <Label fx:id="searchBlueLabel" text="Blue" GridPane.rowIndex="2"/>
+        <JFXTextField fx:id="searchBlueTextField" GridPane.columnIndex="1" GridPane.rowIndex="2"/>
+        <ImageView fx:id="blueValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2"
+                   GridPane.rowIndex="2">
+            <image>
+                <Image url="@../../icons/invalid-icon.png"/>
+            </image>
+        </ImageView>
+        <Label fx:id="searchAlphaLabel" text="Alpha" GridPane.rowIndex="3"/>
+        <JFXTextField fx:id="searchAlphaTextField" GridPane.columnIndex="1" GridPane.rowIndex="3"/>
+        <ImageView fx:id="alphaValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" GridPane.columnIndex="2"
+                   GridPane.rowIndex="3">
+            <image>
+                <Image url="@../../icons/invalid-icon.png"/>
+            </image>
+        </ImageView>
+    </children>
 </GridPane>

--- a/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/YoColorRGBASingleEditorPane.fxml
+++ b/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/YoColorRGBASingleEditorPane.fxml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+
 <?import com.jfoenix.controls.JFXTextField?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
-
-
 <HBox fx:id="mainPane" alignment="CENTER_LEFT" spacing="5.0" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1">
-   <children>
-      <Label fx:id="searchRGBALabel" text="RGBA" HBox.hgrow="NEVER" />
-      <JFXTextField fx:id="searchRGBATextField" />
-      <ImageView fx:id="rgbaValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
-         <image>
-            <Image url="@../../../icons/invalid-icon.png" />
-         </image>
-      </ImageView>
-   </children>
+    <children>
+        <Label fx:id="searchRGBALabel" text="RGBA" HBox.hgrow="NEVER"/>
+        <JFXTextField fx:id="searchRGBATextField"/>
+        <ImageView fx:id="rgbaValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true">
+            <image>
+                <Image url="@../../icons/invalid-icon.png"/>
+            </image>
+        </ImageView>
+    </children>
 </HBox>

--- a/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/YoCompositeListEditorPane.fxml
+++ b/scs2-session-visualizer-jfx/src/main/resources/fxml/editor/YoCompositeListEditorPane.fxml
@@ -3,7 +3,6 @@
 <?import com.jfoenix.controls.JFXButton?>
 <?import com.jfoenix.controls.JFXTextField?>
 <?import de.jensd.fx.glyphs.fontawesome.FontAwesomeIconView?>
-<?import java.lang.String?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.image.Image?>
@@ -13,51 +12,54 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
-
-<VBox fx:id="mainPane" styleClass="graphic-editor-vbox" stylesheets="@../../../css/GeneralStylesheet.css" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1"
-   fx:controller="us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.YoCompositeListEditorPaneController">
-   <children>
-      <HBox alignment="CENTER" styleClass="graphic-editor-hbox">
-         <children>
-            <GridPane fx:id="listSearchGridPane" styleClass="graphic-editor-gridpane" HBox.hgrow="ALWAYS">
-               <columnConstraints>
-                  <ColumnConstraints hgrow="NEVER" />
-                  <ColumnConstraints hgrow="ALWAYS" />
-               </columnConstraints>
-               <rowConstraints>
-                  <RowConstraints vgrow="SOMETIMES" />
-                  <RowConstraints vgrow="SOMETIMES" />
-               </rowConstraints>
-               <children>
-                  <Label fx:id="compositeListLabel" text="Composite list:" />
-                  <JFXTextField fx:id="compositeListSearchTextField" GridPane.columnIndex="1" />
-                  <Label fx:id="listFrameLabel" text="Reference frame:" GridPane.rowIndex="1" />
-                  <JFXTextField fx:id="referenceFrameSearchTextField" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-               </children>
-            </GridPane>
-            <JFXButton fx:id="addCompositeButton" alignment="CENTER_RIGHT" contentDisplay="GRAPHIC_ONLY" graphicTextGap="0.0" onAction="#addComposite" HBox.hgrow="NEVER">
-               <graphic>
-                  <FontAwesomeIconView>
-                     <styleClass>
-                        <String fx:value="add-icon-view" />
-                        <String fx:value="graphic-editor-icon-view" />
-                     </styleClass>
-                  </FontAwesomeIconView>
-               </graphic>
-            </JFXButton>
-         </children>
-      </HBox>
-      <ListView fx:id="listView" prefHeight="50.0" VBox.vgrow="ALWAYS" />
-      <HBox alignment="CENTER" styleClass="graphic-editor-hbox" VBox.vgrow="NEVER">
-         <children>
-            <Label fx:id="numberOfCompositesLabel" text="Number of composites" HBox.hgrow="NEVER" />
-            <JFXTextField fx:id="numberOfCompositesTextField" HBox.hgrow="ALWAYS" />
-            <ImageView fx:id="numberOfCompositesValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true" HBox.hgrow="NEVER">
-               <image>
-                  <Image url="@../../../icons/invalid-icon.png" />
-               </image>
-            </ImageView>
-         </children>
-      </HBox>
-   </children>
+<?import java.lang.String?>
+<VBox fx:id="mainPane" styleClass="graphic-editor-vbox" stylesheets="@../../css/GeneralStylesheet.css" xmlns="http://javafx.com/javafx/8.0.171"
+      xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="us.ihmc.scs2.sessionVisualizer.jfx.controllers.editor.YoCompositeListEditorPaneController">
+    <children>
+        <HBox alignment="CENTER" styleClass="graphic-editor-hbox">
+            <children>
+                <GridPane fx:id="listSearchGridPane" styleClass="graphic-editor-gridpane" HBox.hgrow="ALWAYS">
+                    <columnConstraints>
+                        <ColumnConstraints hgrow="NEVER"/>
+                        <ColumnConstraints hgrow="ALWAYS"/>
+                    </columnConstraints>
+                    <rowConstraints>
+                        <RowConstraints vgrow="SOMETIMES"/>
+                        <RowConstraints vgrow="SOMETIMES"/>
+                    </rowConstraints>
+                    <children>
+                        <Label fx:id="compositeListLabel" text="Composite list:"/>
+                        <JFXTextField fx:id="compositeListSearchTextField" GridPane.columnIndex="1"/>
+                        <Label fx:id="listFrameLabel" text="Reference frame:" GridPane.rowIndex="1"/>
+                        <JFXTextField fx:id="referenceFrameSearchTextField" GridPane.columnIndex="1" GridPane.rowIndex="1"/>
+                    </children>
+                </GridPane>
+                <JFXButton fx:id="addCompositeButton" alignment="CENTER_RIGHT" contentDisplay="GRAPHIC_ONLY" graphicTextGap="0.0" onAction="#addComposite"
+                           HBox.hgrow="NEVER">
+                    <graphic>
+                        <FontAwesomeIconView>
+                            <styleClass>
+                                <String fx:value="add-icon-view"/>
+                                <String fx:value="graphic-editor-icon-view"/>
+                            </styleClass>
+                        </FontAwesomeIconView>
+                    </graphic>
+                </JFXButton>
+            </children>
+        </HBox>
+        <ListView fx:id="listView" prefHeight="50.0" VBox.vgrow="ALWAYS"/>
+        <HBox alignment="CENTER" styleClass="graphic-editor-hbox" VBox.vgrow="NEVER">
+            <children>
+                <Label fx:id="numberOfCompositesLabel" text="Number of composites" HBox.hgrow="NEVER"/>
+                <JFXTextField fx:id="numberOfCompositesTextField" HBox.hgrow="ALWAYS"/>
+                <ImageView fx:id="numberOfCompositesValidImageView" fitHeight="25.0" fitWidth="200.0" pickOnBounds="true" preserveRatio="true"
+                           HBox.hgrow="NEVER">
+                    <image>
+                        <Image url="@../../../icons/invalid-icon.png"/>
+                    </image>
+                </ImageView>
+            </children>
+        </HBox>
+    </children>
 </VBox>


### PR DESCRIPTION
This PR focuses on allowing to have reference frame that are yet to be defined.

This allows loading yoGraphic for instance that relies on reference frames that are yet to be created, and when they are created, the undefined frame gets automatically updated and the yoGraphic as well. This can occur with robot frames which may not be initialized from the beginning but will eventually.