### PR TITLE
Feature/improve simulation rewindability

### DIFF
--- a/scs2-bullet-simulation/src/main/java/us/ihmc/scs2/simulation/bullet/physicsEngine/BulletPhysicsEngine.java
+++ b/scs2-bullet-simulation/src/main/java/us/ihmc/scs2/simulation/bullet/physicsEngine/BulletPhysicsEngine.java
@@ -1,9 +1,5 @@
 package us.ihmc.scs2.simulation.bullet.physicsEngine;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
 import us.ihmc.mecano.tools.JointStateType;
@@ -28,6 +24,11 @@ import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoBoolean;
 import us.ihmc.yoVariables.variable.YoDouble;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 public class BulletPhysicsEngine implements PhysicsEngine
 {
    private final BulletMultiBodyDynamicsWorld bulletMultiBodyDynamicsWorld;
@@ -38,21 +39,26 @@ public class BulletPhysicsEngine implements PhysicsEngine
 
    private final YoRegistry rootRegistry;
    private final YoRegistry physicsEngineRegistry = new YoRegistry(getClass().getSimpleName());
-   private final YoDouble runTickExpectedTimeRate = new YoDouble("runTickExpectedTimeRate", physicsEngineRegistry);
-   private final YoTimer runBulletPhysicsEngineSimulateTimer = new YoTimer("runBulletPhysicsEngineSimulateTimer", TimeUnit.MILLISECONDS, physicsEngineRegistry);
-   private final YoTimer runBulletStepSimulateTimer = new YoTimer("runBulletStepSimulateTimer", TimeUnit.MILLISECONDS, physicsEngineRegistry);
-   private final YoTimer runControllerManagerTimer = new YoTimer("runControllerManagerTimer", TimeUnit.MILLISECONDS, physicsEngineRegistry);
-   private final YoTimer runPullStateFromBullet = new YoTimer("runPullStateFromBulletTimer", TimeUnit.MILLISECONDS, physicsEngineRegistry);
-   private final YoTimer runPushStateToBulletTimer = new YoTimer("runPushStateToBullet", TimeUnit.MILLISECONDS, physicsEngineRegistry);
-   private final YoTimer runUpdateFramesSensorsTimer = new YoTimer("runUpdateFramesSensorsTimer", TimeUnit.MILLISECONDS, physicsEngineRegistry);
-   private final YoDouble bulletPhysicsEngineRealTimeRate = new YoDouble("bulletPhysicsEngineRealTimeRate", physicsEngineRegistry);
+   private final YoRegistry physicsEngineStatisticsRegistry = new YoRegistry("physicsEngineStatistics");
+   private final YoDouble runTickExpectedTimeRate = new YoDouble("runTickExpectedTimeRate", physicsEngineStatisticsRegistry);
+   private final YoTimer runBulletPhysicsEngineSimulateTimer = new YoTimer("runBulletPhysicsEngineSimulateTimer",
+                                                                           TimeUnit.MILLISECONDS,
+                                                                           physicsEngineStatisticsRegistry);
+   private final YoTimer runBulletStepSimulateTimer = new YoTimer("runBulletStepSimulateTimer", TimeUnit.MILLISECONDS, physicsEngineStatisticsRegistry);
+   private final YoTimer runControllerManagerTimer = new YoTimer("runControllerManagerTimer", TimeUnit.MILLISECONDS, physicsEngineStatisticsRegistry);
+   private final YoTimer runPullStateFromBullet = new YoTimer("runPullStateFromBulletTimer", TimeUnit.MILLISECONDS, physicsEngineStatisticsRegistry);
+   private final YoTimer runPushStateToBulletTimer = new YoTimer("runPushStateToBullet", TimeUnit.MILLISECONDS, physicsEngineStatisticsRegistry);
+   private final YoTimer runUpdateFramesSensorsTimer = new YoTimer("runUpdateFramesSensorsTimer", TimeUnit.MILLISECONDS, physicsEngineStatisticsRegistry);
+   private final YoDouble bulletPhysicsEngineRealTimeRate = new YoDouble("bulletPhysicsEngineRealTimeRate", physicsEngineStatisticsRegistry);
    private final ArrayList<YoPoint3D> contactPoints = new ArrayList<>();
+
    {
       for (int i = 0; i < 100; i++)
       {
          contactPoints.add(new YoPoint3D("contactPoint" + i, physicsEngineRegistry));
       }
    }
+
    private final YoBulletMultiBodyParameters globalMultiBodyParameters;
    private final YoBulletMultiBodyJointParameters globalMultiBodyJointParameters;
    private final YoBulletContactSolverInfoParameters globalContactSolverInfoParameters;
@@ -64,6 +70,8 @@ public class BulletPhysicsEngine implements PhysicsEngine
    {
       this.inertialFrame = inertialFrame;
       this.rootRegistry = rootRegistry;
+
+      physicsEngineRegistry.addChild(physicsEngineStatisticsRegistry);
 
       globalMultiBodyParameters = new YoBulletMultiBodyParameters("globalMultiBody", physicsEngineRegistry);
       globalMultiBodyJointParameters = new YoBulletMultiBodyJointParameters("globalMultiBodyJoint", physicsEngineRegistry);
@@ -97,7 +105,7 @@ public class BulletPhysicsEngine implements PhysicsEngine
    {
       if (!hasBeenInitialized)
       {
-         initialize(gravity);         
+         initialize(gravity);
          return;
       }
 
@@ -125,6 +133,8 @@ public class BulletPhysicsEngine implements PhysicsEngine
       runControllerManagerTimer.start();
       for (BulletRobot robot : robotList)
       {
+         robot.updateFrames();
+         robot.updateSensors();
          robot.getControllerManager().updateControllers(currentTime);
          robot.getControllerManager().writeControllerOutput(JointStateType.EFFORT);
          robot.getControllerManager().writeControllerOutputForJointsToIgnore(JointStateType.values());
@@ -165,11 +175,6 @@ public class BulletPhysicsEngine implements PhysicsEngine
       runPullStateFromBullet.stop();
 
       runUpdateFramesSensorsTimer.start();
-      for (BulletRobot robot : robotList)
-      {
-         robot.updateFrames();
-         robot.updateSensors();
-      }
       runUpdateFramesSensorsTimer.stop();
       runBulletPhysicsEngineSimulateTimer.stop();
       bulletPhysicsEngineRealTimeRate.set(runTickExpectedTimeRate.getValue() / runBulletPhysicsEngineSimulateTimer.getTimer().getValue());
@@ -180,6 +185,8 @@ public class BulletPhysicsEngine implements PhysicsEngine
    {
       for (BulletRobot robot : robotList)
       {
+         robot.updateFrames();
+         robot.updateSensors();
          robot.getControllerManager().pauseControllers();
       }
    }
@@ -312,5 +319,4 @@ public class BulletPhysicsEngine implements PhysicsEngine
    {
       return globalContactSolverInfoParameters;
    }
-
 }

--- a/scs2-examples/src/test/java/us/ihmc/scs2/examples/SimulationRewindabilityTester.java
+++ b/scs2-examples/src/test/java/us/ihmc/scs2/examples/SimulationRewindabilityTester.java
@@ -21,6 +21,7 @@ import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizer;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerControls;
 import us.ihmc.scs2.simulation.SimulationSession;
 import us.ihmc.scs2.simulation.SimulationSessionControls;
+import us.ihmc.scs2.simulation.bullet.physicsEngine.BulletPhysicsEngine;
 import us.ihmc.scs2.simulation.physicsEngine.PhysicsEngineFactory;
 import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoDouble;
@@ -203,6 +204,13 @@ public class SimulationRewindabilityTester extends RobotDefinition
    public void testImpulseBasedPhysicsEngineRewindability()
    {
       PhysicsEngineFactory physicsEngineFactoryToTest = SimulationConstructionSet2.impulseBasedPhysicsEngineFactory();
+      assertRewindability(physicsEngineFactoryToTest);
+   }
+
+   @Test
+   public void testBulletPhysicsEngineRewindability()
+   {
+      PhysicsEngineFactory physicsEngineFactoryToTest = BulletPhysicsEngine::new;
       assertRewindability(physicsEngineFactoryToTest);
    }
 

--- a/scs2-examples/src/test/java/us/ihmc/scs2/examples/SimulationRewindabilityTester.java
+++ b/scs2-examples/src/test/java/us/ihmc/scs2/examples/SimulationRewindabilityTester.java
@@ -1,0 +1,329 @@
+package us.ihmc.scs2.examples;
+
+import org.junit.jupiter.api.Test;
+import us.ihmc.euclid.tools.EuclidCoreIOTools;
+import us.ihmc.euclid.tuple3D.Point3D;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
+import us.ihmc.mecano.tools.MomentOfInertiaFactory;
+import us.ihmc.scs2.SimulationConstructionSet2;
+import us.ihmc.scs2.definition.robot.KinematicPointDefinition;
+import us.ihmc.scs2.definition.robot.RevoluteJointDefinition;
+import us.ihmc.scs2.definition.robot.RigidBodyDefinition;
+import us.ihmc.scs2.definition.robot.RobotDefinition;
+import us.ihmc.scs2.definition.robot.SixDoFJointDefinition;
+import us.ihmc.scs2.definition.state.SixDoFJointState;
+import us.ihmc.scs2.definition.visual.ColorDefinitions;
+import us.ihmc.scs2.definition.visual.MaterialDefinition;
+import us.ihmc.scs2.definition.visual.VisualDefinition;
+import us.ihmc.scs2.definition.visual.VisualDefinitionFactory;
+import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizer;
+import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerControls;
+import us.ihmc.scs2.simulation.SimulationSession;
+import us.ihmc.scs2.simulation.SimulationSessionControls;
+import us.ihmc.scs2.simulation.physicsEngine.PhysicsEngineFactory;
+import us.ihmc.yoVariables.registry.YoRegistry;
+import us.ihmc.yoVariables.variable.YoDouble;
+import us.ihmc.yoVariables.variable.YoVariable;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SimulationRewindabilityTester extends RobotDefinition
+{
+   private enum RobotSide
+   {
+      LEFT, RIGHT;
+
+      public String getLowerCaseName()
+      {
+         return name().toLowerCase();
+      }
+   }
+
+   ;
+   // Materials:
+   private final MaterialDefinition redMaterial = new MaterialDefinition(ColorDefinitions.Red());
+   private final MaterialDefinition greenMaterial = new MaterialDefinition(ColorDefinitions.Green());
+   private final MaterialDefinition grayMaterial = new MaterialDefinition(ColorDefinitions.Gray());
+
+   private final EnumMap<RobotSide, MaterialDefinition> appendageMaterial = new EnumMap<>(Map.of(RobotSide.LEFT, redMaterial, RobotSide.RIGHT, greenMaterial));
+
+   // Joint Spacing:
+   private static final double hipToHipSpacingY = 0.15;
+   private static final double thighLength = 0.40;
+
+   // Pelvis and Leg Mass Properties:
+   private static final double pelvisMass = 3.0;
+   private static final double pelvisRadiusOfGyrationX = 0.1;
+   private static final double pelvisRadiusOfGyrationY = 0.1;
+   private static final double pelvisRadiusOfGyrationZ = 0.1;
+
+   private static final double thighMass = 5.0;
+   private static final double thighRadiusOfGyrationX = 0.05;
+   private static final double thighRadiusOfGyrationY = 0.05;
+   private static final double thighRadiusOfGyrationZ = thighLength * 0.8;
+
+   // Visual Properties:
+   private static final double thighTopVisualRadius = 0.05;
+   private static final double thighVisualRadius = 0.025;
+
+   // Joint Definitions:
+   private SixDoFJointDefinition pelvisJointDefinition;
+   private RevoluteJointDefinition leftHipZ;
+
+   public SimulationRewindabilityTester()
+   {
+      super("SimulationRewindabilityTester");
+
+      RigidBodyDefinition rootBody = new RigidBodyDefinition("rootBody");
+      pelvisJointDefinition = createPelvis();
+      rootBody.addChildJoint(pelvisJointDefinition);
+
+      leftHipZ = createHipZ(RobotSide.LEFT);
+      pelvisJointDefinition.getSuccessor().addChildJoint(leftHipZ);
+
+      setRootBodyDefinition(rootBody);
+   }
+
+   public void setInitialState(boolean setInitialLinearVelocity, boolean setInitialAngularVelocity)
+   {
+      SixDoFJointState initialSixDoFState = new SixDoFJointState(new YawPitchRoll(0.1, 0.02, 0.03), new Point3D(0.02, 0.03, 0.04));
+
+      Vector3D initialLinearVelocity = new Vector3D();
+      Vector3D initialAngularVelocity = new Vector3D();
+
+      if (setInitialLinearVelocity)
+         initialLinearVelocity.set(0.2, 0.13, -0.2);
+
+      if (setInitialAngularVelocity)
+         initialAngularVelocity.set(0.2, 0.6, -0.2);
+
+      initialSixDoFState.setVelocity(initialAngularVelocity, initialLinearVelocity);
+      pelvisJointDefinition.setInitialJointState(initialSixDoFState);
+   }
+
+   // Joints and Rigid Bodies:
+   private SixDoFJointDefinition createPelvis()
+   {
+      SixDoFJointDefinition pelvisJointDefinition = new SixDoFJointDefinition("pelvis");
+
+      RigidBodyDefinition pelvisRigidBody = new RigidBodyDefinition("pelvis");
+      pelvisRigidBody.setMass(pelvisMass);
+      pelvisRigidBody.setMomentOfInertia(MomentOfInertiaFactory.fromMassAndRadiiOfGyration(pelvisMass,
+                                                                                           pelvisRadiusOfGyrationX,
+                                                                                           pelvisRadiusOfGyrationY,
+                                                                                           pelvisRadiusOfGyrationZ));
+      pelvisRigidBody.setCenterOfMassOffset(new Vector3D());
+
+      KinematicPointDefinition pelvisMiddlePoint = new KinematicPointDefinition("pelvisPoint");
+      pelvisJointDefinition.addKinematicPointDefinition(pelvisMiddlePoint);
+
+      List<VisualDefinition> pelvisVisuals = createPelvisVisuals();
+
+      pelvisRigidBody.addVisualDefinitions(pelvisVisuals);
+      pelvisJointDefinition.setSuccessor(pelvisRigidBody);
+
+      return pelvisJointDefinition;
+   }
+
+   private RevoluteJointDefinition createHipZ(RobotSide robotSide)
+   {
+      String sidePrefix = robotSide.getLowerCaseName();
+
+      RevoluteJointDefinition hipZJoint = new RevoluteJointDefinition(sidePrefix + "HipZ", new Point3D(0.0, 0.0, 0.0), new Vector3D(0.0, 0.0, 1.0));
+
+      RigidBodyDefinition thighRigidBody = new RigidBodyDefinition(sidePrefix + "Thigh");
+      thighRigidBody.setMass(thighMass);
+      thighRigidBody.setMomentOfInertia(MomentOfInertiaFactory.fromMassAndRadiiOfGyration(thighMass,
+                                                                                          thighRadiusOfGyrationX,
+                                                                                          thighRadiusOfGyrationY,
+                                                                                          thighRadiusOfGyrationZ));
+      thighRigidBody.setCenterOfMassOffset(new Vector3D(0.0, 0.0, -thighLength / 2.0));
+
+      List<VisualDefinition> thighVisualDefinitions = createThighVisuals(robotSide);
+      thighRigidBody.addVisualDefinitions(thighVisualDefinitions);
+
+      hipZJoint.setSuccessor(thighRigidBody);
+      return hipZJoint;
+   }
+
+   // Visuals:
+
+   private List<VisualDefinition> createPelvisVisuals()
+   {
+      VisualDefinitionFactory pelvisVisualFactory = new VisualDefinitionFactory();
+
+      pelvisVisualFactory.appendTranslation(new Vector3D(0.0, 0.0, 0.04));
+      pelvisVisualFactory.addCylinder(0.02, hipToHipSpacingY / 2.0, redMaterial);
+
+      return pelvisVisualFactory.getVisualDefinitions();
+   }
+
+   private List<VisualDefinition> createThighVisuals(RobotSide robotSide)
+   {
+      VisualDefinitionFactory thighVisualFactory = new VisualDefinitionFactory();
+
+      thighVisualFactory.addSphere(thighTopVisualRadius, grayMaterial);
+      thighVisualFactory.appendTranslation(0.0, 0.0, -thighLength / 2.0);
+      thighVisualFactory.addCylinder(thighLength, thighVisualRadius, appendageMaterial.get(robotSide));
+
+      return thighVisualFactory.getVisualDefinitions();
+   }
+
+   private record VariableEntry(String name, double value)
+   {
+   }
+
+   private record SimulationState(List<VariableEntry> variableEntries)
+   {
+      @Override
+      public String toString()
+      {
+         return getClass().getSimpleName() + ":" + EuclidCoreIOTools.getCollectionString("[\n\t",
+                                                                                         "\n]",
+                                                                                         "\n\t",
+                                                                                         variableEntries,
+                                                                                         entry -> entry.name + ": " + entry.value);
+      }
+   }
+
+   @Test
+   public void testContactPointBasedPhysicsEngineRewindability()
+   {
+      PhysicsEngineFactory physicsEngineFactoryToTest = SimulationConstructionSet2.contactPointBasedPhysicsEngineFactory();
+      assertRewindability(physicsEngineFactoryToTest);
+   }
+
+   @Test
+   public void testImpulseBasedPhysicsEngineRewindability()
+   {
+      PhysicsEngineFactory physicsEngineFactoryToTest = SimulationConstructionSet2.impulseBasedPhysicsEngineFactory();
+      assertRewindability(physicsEngineFactoryToTest);
+   }
+
+   private static void assertRewindability(PhysicsEngineFactory physicsEngineFactoryToTest)
+   {
+      boolean applyTorque = true;
+      boolean setGravity = true;
+      boolean setInitialLinearVelocity = true;
+      boolean setInitialAngularVelocity = true;
+      boolean visualize = false;
+
+      SimulationRewindabilityTester definition = new SimulationRewindabilityTester();
+
+      definition.setInitialState(setInitialLinearVelocity, setInitialAngularVelocity);
+
+      SimulationSession simulationSession = new SimulationSession(physicsEngineFactoryToTest);
+      SimulationSessionControls simulationSessionControls = simulationSession.getSimulationSessionControls();
+
+      simulationSession.addRobot(definition);
+
+      simulationSession.setSessionDTSeconds(0.0001);
+      simulationSession.setBufferRecordTickPeriod(1);
+
+      if (setGravity)
+         simulationSession.setGravity(0.1, 0.05, 0.02);
+      else
+         simulationSession.setGravity(0.0, 0.0, 0.0);
+
+      simulationSession.submitBufferSizeRequestAndWait(40000);
+
+      YoRegistry rootRegistry = simulationSession.getRootRegistry();
+      YoDouble tau_leftHipZ = (YoDouble) rootRegistry.findVariable("tau_leftHipZ");
+      YoDouble qd_pelvis_x = (YoDouble) rootRegistry.findVariable("qd_pelvis_x");
+      YoDouble qdd_pelvis_x = (YoDouble) rootRegistry.findVariable("qdd_pelvis_x");
+      YoDouble time = (YoDouble) rootRegistry.findVariable("time[sec]");
+
+      if (applyTorque)
+         tau_leftHipZ.set(1.0);
+
+      SessionVisualizerControls sessionVisualizerControls = null;
+      if (visualize)
+      {
+         sessionVisualizerControls = SessionVisualizer.startSessionVisualizer(simulationSession);
+         sessionVisualizerControls.waitUntilVisualizerFullyUp();
+      }
+
+      double initialSimulationDuration = 0.2;
+
+      // Use these doubles to make a lot of tick changes:
+      //      double simulationDurationToCheckPoint = 0.2;
+      //      double simulationDurationAfterCheckPoint = 0.2;
+
+      // Use these ints to just do one tick tests:
+      int simulationDurationToCheckPoint = 1;
+      int simulationDurationAfterCheckPoint = 1;
+
+      int numberOfRuns = 4;
+
+      simulationSessionControls.simulateNow(initialSimulationDuration);
+      simulationSessionControls.setBufferInPoint();
+
+      SimulationState[] begin_states = new SimulationState[numberOfRuns];
+      SimulationState[] check_states = new SimulationState[numberOfRuns];
+      SimulationState[] end_states = new SimulationState[numberOfRuns];
+
+      for (int i = 0; i < numberOfRuns; i++)
+      {
+         simulationSessionControls.gotoBufferInPoint();
+         begin_states[i] = extractSimulationState(rootRegistry);
+
+         simulationSessionControls.simulateNow(simulationDurationToCheckPoint);
+         check_states[i] = extractSimulationState(rootRegistry);
+
+         System.out.println("\nt = " + time);
+         System.out.println(qd_pelvis_x);
+         System.out.println(qdd_pelvis_x);
+
+         simulationSessionControls.simulateNow(simulationDurationAfterCheckPoint);
+         end_states[i] = extractSimulationState(rootRegistry);
+      }
+
+      System.out.println("Done doing rewindability tests!");
+
+      if (sessionVisualizerControls != null)
+         sessionVisualizerControls.shutdownSession();
+      else
+         simulationSession.shutdownSession();
+
+      for (int i = 0; i < numberOfRuns - 1; i++)
+      {
+         assertEquals(begin_states[i], begin_states[i + 1]);
+         assertEquals(check_states[i], check_states[i + 1]);
+         assertEquals(end_states[i], end_states[i + 1]);
+      }
+   }
+
+   private static SimulationState extractSimulationState(YoRegistry rootRegistry)
+   {
+      List<YoVariable> allVariables = collectSubtreeVariables(rootRegistry);
+      return new SimulationState(allVariables.stream().map(variable -> new VariableEntry(variable.getName(), variable.getValueAsDouble())).toList());
+   }
+
+   private static ArrayList<YoVariable> collectSubtreeVariables(YoRegistry registry)
+   {
+      ArrayList<YoVariable> variables = new ArrayList<>();
+      collectSubtreeVariables(registry, variables);
+      return variables;
+   }
+
+   private static void collectSubtreeVariables(YoRegistry registry, List<YoVariable> variablesToPack)
+   {
+      if (registry.getName().contains("Statistics"))
+         return;
+
+      // Add ours:
+      variablesToPack.addAll(registry.getVariables());
+
+      // Add children's recursively:
+      for (YoRegistry child : registry.getChildren())
+      {
+         collectSubtreeVariables(child, variablesToPack);
+      }
+   }
+}

--- a/scs2-shared-memory/src/main/java/us/ihmc/scs2/sharedMemory/YoVariableBuffer.java
+++ b/scs2-shared-memory/src/main/java/us/ihmc/scs2/sharedMemory/YoVariableBuffer.java
@@ -87,4 +87,10 @@ public abstract class YoVariableBuffer<T extends YoVariable>
    public abstract double[] getAsDoubleBuffer();
 
    public abstract void dispose();
+
+   @Override
+   public String toString()
+   {
+      return "%s [yoVariable=%s, properties=%s]".formatted(getClass().getSimpleName(), yoVariable, properties);
+   }
 }

--- a/scs2-simulation/src/main/java/us/ihmc/scs2/simulation/physicsEngine/contactPointBased/ContactPointBasedPhysicsEngine.java
+++ b/scs2-simulation/src/main/java/us/ihmc/scs2/simulation/physicsEngine/contactPointBased/ContactPointBasedPhysicsEngine.java
@@ -108,6 +108,8 @@ public class ContactPointBasedPhysicsEngine implements PhysicsEngine
 
       for (ContactPointBasedRobot robot : robotList)
       {
+         robot.updateFrames();
+         robot.updateSensors();
          robot.resetCalculators();
          robot.getControllerManager().updateControllers(currentTime);
          robot.getControllerManager().writeControllerOutput(JointStateType.EFFORT);
@@ -171,8 +173,6 @@ public class ContactPointBasedPhysicsEngine implements PhysicsEngine
                                       });
 
          robot.integrateState(dt);
-         robot.updateFrames();
-         robot.updateSensors();
       }
    }
 
@@ -181,6 +181,8 @@ public class ContactPointBasedPhysicsEngine implements PhysicsEngine
    {
       for (ContactPointBasedRobot robot : robotList)
       {
+         robot.updateFrames();
+         robot.updateSensors();
          robot.getControllerManager().pauseControllers();
       }
    }

--- a/scs2-simulation/src/main/java/us/ihmc/scs2/simulation/robot/multiBodySystem/SimFloatingRootJoint.java
+++ b/scs2-simulation/src/main/java/us/ihmc/scs2/simulation/robot/multiBodySystem/SimFloatingRootJoint.java
@@ -62,22 +62,21 @@ public class SimFloatingRootJoint extends SimSixDoFJoint implements SimJointBasi
                                                   updatingYPR.setFalse();
                                                }
                                             });
-
-      jointYawPitchRoll.attachVariableChangedListener(v ->
-                                                      {
-                                                         if (updatingYPR.booleanValue())
-                                                            return;
-
-                                                         updatingQuat.setTrue();
-                                                         try
-                                                         {
-                                                            jointQuaternion.set(jointYawPitchRoll);
-                                                         }
-                                                         finally
-                                                         {
-                                                            updatingQuat.setFalse();
-                                                         }
-                                                      });
+      // FIXME: Edge case: When rewinding, it's screw up the jointQuaternion. Need to find a way to prevent this.
+      //      jointYawPitchRoll.attachVariableChangedListener(v ->
+      //                                                      {
+      //                                                         if (updatingYPR.booleanValue())
+      //                                                            return;
+      //                                                         updatingQuat.setTrue();
+      //                                                         try
+      //                                                         {
+      //                                                            jointQuaternion.set(jointYawPitchRoll);
+      //                                                         }
+      //                                                         finally
+      //                                                         {
+      //                                                            updatingQuat.setFalse();
+      //                                                         }
+      //                                                      });
 
       jointLinearVelocity = new YoFrameVector3D("qd" + varName + "world_", beforeJointFrame, registry);
       YoFixedFrameTwist jointTwist = getJointTwist();
@@ -95,15 +94,16 @@ public class SimFloatingRootJoint extends SimSixDoFJoint implements SimJointBasi
                                                                   updatingLinVel.setFalse();
                                                                });
 
-      jointLinearVelocity.attachVariableChangedListener(v ->
-                                                        {
-                                                           if (updatingLinVel.booleanValue())
-                                                              return;
-                                                           updatingTwist.setTrue();
-                                                           jointQuaternion.inverseTransform((Tuple3DReadOnly) jointLinearVelocity,
-                                                                                            (Tuple3DBasics) jointTwist.getLinearPart());
-                                                           updatingTwist.setFalse();
-                                                        });
+      // FIXME: Edge case: When rewinding, it's screw up the jointTwist. Need to find a way to prevent this.
+      //      jointLinearVelocity.attachVariableChangedListener(v ->
+      //                                                        {
+      //                                                           if (updatingLinVel.booleanValue())
+      //                                                              return;
+      //                                                           updatingTwist.setTrue();
+      //                                                           jointQuaternion.inverseTransform((Tuple3DReadOnly) jointLinearVelocity,
+      //                                                                                            (Tuple3DBasics) jointTwist.getLinearPart());
+      //                                                           updatingTwist.setFalse();
+      //                                                        });
 
       jointLinearAcceleration = new YoFrameVector3D("qdd" + varName + "world_", beforeJointFrame, registry);
       YoFixedFrameSpatialAcceleration jointSpatialAcceleration = getJointAcceleration();
@@ -123,18 +123,18 @@ public class SimFloatingRootJoint extends SimSixDoFJoint implements SimJointBasi
                                                                                 jointQuaternion.transform((Tuple3DBasics) jointLinearAcceleration);
                                                                                 updatingLinAcc.setFalse();
                                                                              });
-
-      jointLinearAcceleration.attachVariableChangedListener(v ->
-                                                            {
-                                                               if (updatingLinAcc.booleanValue())
-                                                                  return;
-                                                               updatingSpAcc.setTrue();
-                                                               jointQuaternion.inverseTransform((Tuple3DReadOnly) jointLinearAcceleration,
-                                                                                                (Tuple3DBasics) jointSpatialAcceleration.getLinearPart());
-                                                               jointSpatialAcceleration.addCrossToLinearPart(jointTwist.getLinearPart(),
-                                                                                                             jointTwist.getAngularPart());
-                                                               updatingSpAcc.setFalse();
-                                                            });
+      // FIXME: Edge case: When rewinding, it's screw up the jointSpatialAcceleration. Need to find a way to prevent this.
+      //      jointLinearAcceleration.attachVariableChangedListener(v ->
+      //                                                            {
+      //                                                               if (updatingLinAcc.booleanValue())
+      //                                                                  return;
+      //                                                               updatingSpAcc.setTrue();
+      //                                                               jointQuaternion.inverseTransform((Tuple3DReadOnly) jointLinearAcceleration,
+      //                                                                                                (Tuple3DBasics) jointSpatialAcceleration.getLinearPart());
+      //                                                               jointSpatialAcceleration.addCrossToLinearPart(jointTwist.getLinearPart(),
+      //                                                                                                             jointTwist.getAngularPart());
+      //                                                               updatingSpAcc.setFalse();
+      //                                                            });
    }
 
    @Override

--- a/scs2-simulation/src/main/java/us/ihmc/scs2/simulation/robot/multiBodySystem/SimFloatingRootJoint.java
+++ b/scs2-simulation/src/main/java/us/ihmc/scs2/simulation/robot/multiBodySystem/SimFloatingRootJoint.java
@@ -1,10 +1,14 @@
 package us.ihmc.scs2.simulation.robot.multiBodySystem;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import us.ihmc.euclid.Axis3D;
+import us.ihmc.euclid.tools.EuclidCoreTools;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
-import us.ihmc.euclid.tuple3D.interfaces.Tuple3DBasics;
-import us.ihmc.euclid.tuple3D.interfaces.Tuple3DReadOnly;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
+import us.ihmc.euclid.tuple4D.interfaces.QuaternionReadOnly;
+import us.ihmc.mecano.spatial.interfaces.TwistReadOnly;
 import us.ihmc.mecano.tools.MecanoTools;
 import us.ihmc.mecano.yoVariables.spatial.YoFixedFrameSpatialAcceleration;
 import us.ihmc.mecano.yoVariables.spatial.YoFixedFrameTwist;
@@ -16,6 +20,8 @@ import us.ihmc.yoVariables.euclid.referenceFrame.YoFrameQuaternion;
 import us.ihmc.yoVariables.euclid.referenceFrame.YoFrameVector3D;
 import us.ihmc.yoVariables.euclid.referenceFrame.YoFrameYawPitchRoll;
 import us.ihmc.yoVariables.registry.YoRegistry;
+
+import java.util.function.BiConsumer;
 
 public class SimFloatingRootJoint extends SimSixDoFJoint implements SimJointBasics, SimFloatingJointBasics
 {
@@ -44,97 +50,167 @@ public class SimFloatingRootJoint extends SimSixDoFJoint implements SimJointBasi
       jointYawPitchRoll = new YoFrameYawPitchRoll("q" + varName, beforeJointFrame, registry);
       YoFrameQuaternion jointQuaternion = getJointPose().getOrientation();
 
-      MutableBoolean updatingYPR = new MutableBoolean(false);
-      MutableBoolean updatingQuat = new MutableBoolean(false);
-
-      jointQuaternion.getYoQs().addListener(v ->
-                                            {
-                                               if (updatingQuat.booleanValue())
-                                                  return;
-
-                                               updatingYPR.setTrue();
-                                               try
-                                               {
-                                                  jointYawPitchRoll.set(jointQuaternion);
-                                               }
-                                               finally
-                                               {
-                                                  updatingYPR.setFalse();
-                                               }
-                                            });
-      // FIXME: Edge case: When rewinding, it's screw up the jointQuaternion. Need to find a way to prevent this.
-      //      jointYawPitchRoll.attachVariableChangedListener(v ->
-      //                                                      {
-      //                                                         if (updatingYPR.booleanValue())
-      //                                                            return;
-      //                                                         updatingQuat.setTrue();
-      //                                                         try
-      //                                                         {
-      //                                                            jointQuaternion.set(jointYawPitchRoll);
-      //                                                         }
-      //                                                         finally
-      //                                                         {
-      //                                                            updatingQuat.setFalse();
-      //                                                         }
-      //                                                      });
+      buildOrientationListeners(jointQuaternion, jointYawPitchRoll);
 
       jointLinearVelocity = new YoFrameVector3D("qd" + varName + "world_", beforeJointFrame, registry);
       YoFixedFrameTwist jointTwist = getJointTwist();
 
-      MutableBoolean updatingLinVel = new MutableBoolean(false);
-      MutableBoolean updatingTwist = new MutableBoolean(false);
-
-      jointTwist.getLinearPart().attachVariableChangedListener(v ->
-                                                               {
-                                                                  if (updatingTwist.booleanValue())
-                                                                     return;
-                                                                  updatingLinVel.setTrue();
-                                                                  jointQuaternion.transform((Tuple3DReadOnly) jointTwist.getLinearPart(),
-                                                                                            (Tuple3DBasics) jointLinearVelocity);
-                                                                  updatingLinVel.setFalse();
-                                                               });
-
-      // FIXME: Edge case: When rewinding, it's screw up the jointTwist. Need to find a way to prevent this.
-      //      jointLinearVelocity.attachVariableChangedListener(v ->
-      //                                                        {
-      //                                                           if (updatingLinVel.booleanValue())
-      //                                                              return;
-      //                                                           updatingTwist.setTrue();
-      //                                                           jointQuaternion.inverseTransform((Tuple3DReadOnly) jointLinearVelocity,
-      //                                                                                            (Tuple3DBasics) jointTwist.getLinearPart());
-      //                                                           updatingTwist.setFalse();
-      //                                                        });
+      buildVectorListeners(jointQuaternion, jointTwist.getLinearPart(), jointLinearVelocity, jointQuaternion::transform, jointQuaternion::inverseTransform);
 
       jointLinearAcceleration = new YoFrameVector3D("qdd" + varName + "world_", beforeJointFrame, registry);
       YoFixedFrameSpatialAcceleration jointSpatialAcceleration = getJointAcceleration();
 
-      MutableBoolean updatingLinAcc = new MutableBoolean(false);
-      MutableBoolean updatingSpAcc = new MutableBoolean(false);
+      buildVectorListeners(jointQuaternion,
+                           jointSpatialAcceleration.getLinearPart(),
+                           jointLinearAcceleration,
+                           (a, b) -> transformLinearAcceleration(jointQuaternion, jointTwist, a, b),
+                           (b, a) -> inverseTransformLinearAcceleration(jointQuaternion, jointTwist, b, a));
+   }
 
-      jointSpatialAcceleration.getLinearPart().attachVariableChangedListener(v ->
-                                                                             {
-                                                                                if (updatingSpAcc.booleanValue())
-                                                                                   return;
-                                                                                updatingLinAcc.setTrue();
-                                                                                jointLinearAcceleration.set((Vector3DReadOnly) jointSpatialAcceleration.getLinearPart());
-                                                                                MecanoTools.addCrossToVector(jointTwist.getAngularPart(),
-                                                                                                             jointTwist.getLinearPart(),
-                                                                                                             jointLinearAcceleration);
-                                                                                jointQuaternion.transform((Tuple3DBasics) jointLinearAcceleration);
-                                                                                updatingLinAcc.setFalse();
-                                                                             });
-      // FIXME: Edge case: When rewinding, it's screw up the jointSpatialAcceleration. Need to find a way to prevent this.
-      //      jointLinearAcceleration.attachVariableChangedListener(v ->
-      //                                                            {
-      //                                                               if (updatingLinAcc.booleanValue())
-      //                                                                  return;
-      //                                                               updatingSpAcc.setTrue();
-      //                                                               jointQuaternion.inverseTransform((Tuple3DReadOnly) jointLinearAcceleration,
-      //                                                                                                (Tuple3DBasics) jointSpatialAcceleration.getLinearPart());
-      //                                                               jointSpatialAcceleration.addCrossToLinearPart(jointTwist.getLinearPart(),
-      //                                                                                                             jointTwist.getAngularPart());
-      //                                                               updatingSpAcc.setFalse();
-      //                                                            });
+   private static void inverseTransformLinearAcceleration(QuaternionReadOnly quaternion,
+                                                          TwistReadOnly twist,
+                                                          Vector3DReadOnly linearAccelerationOriginal,
+                                                          Vector3DBasics linearAccelerationTransformed)
+   {
+      quaternion.inverseTransform(linearAccelerationOriginal, linearAccelerationTransformed);
+      MecanoTools.addCrossToVector(twist.getLinearPart(), twist.getAngularPart(), linearAccelerationTransformed);
+   }
+
+   private static void transformLinearAcceleration(QuaternionReadOnly quaternion,
+                                                   TwistReadOnly twist,
+                                                   Vector3DReadOnly linearAccelerationOriginal,
+                                                   Vector3DBasics linearAccelerationTransformed)
+   {
+      linearAccelerationTransformed.set(linearAccelerationOriginal);
+      MecanoTools.addCrossToVector(twist.getAngularPart(), twist.getLinearPart(), linearAccelerationTransformed);
+      quaternion.transform(linearAccelerationTransformed);
+   }
+
+   private static void buildOrientationListeners(YoFrameQuaternion quaternion, YoFrameYawPitchRoll yawPitchRoll)
+   {
+      MutableBoolean updatingYPR = new MutableBoolean(false);
+      MutableBoolean updatingQuat = new MutableBoolean(false);
+
+      quaternion.getYoQs().addListener(v ->
+                                       {
+                                          if (updatingQuat.booleanValue())
+                                             return;
+
+                                          updatingYPR.setTrue();
+                                          try
+                                          {
+                                             yawPitchRoll.set(quaternion);
+                                          }
+                                          finally
+                                          {
+                                             updatingYPR.setFalse();
+                                          }
+                                       });
+
+      double updateThreshold = 1.0e-6;
+
+      // Doing 1 component at a time to avoid updating the quaternion with old data.
+      yawPitchRoll.getYoYaw().addListener(v ->
+                                          {
+                                             if (updatingYPR.booleanValue())
+                                                return;
+                                             updatingQuat.setTrue();
+                                             try
+                                             {
+                                                if (!EuclidCoreTools.epsilonEquals(quaternion.getYaw(), yawPitchRoll.getYaw(), updateThreshold))
+                                                   quaternion.setYawPitchRoll(yawPitchRoll.getYaw(), quaternion.getPitch(), quaternion.getRoll());
+                                             }
+                                             finally
+                                             {
+                                                updatingQuat.setFalse();
+                                             }
+                                          });
+
+      yawPitchRoll.getYoPitch().addListener(v ->
+                                            {
+                                               if (updatingYPR.booleanValue())
+                                                  return;
+                                               updatingQuat.setTrue();
+                                               try
+                                               {
+                                                  if (!EuclidCoreTools.epsilonEquals(quaternion.getPitch(), yawPitchRoll.getPitch(), updateThreshold))
+                                                     quaternion.setYawPitchRoll(quaternion.getYaw(), yawPitchRoll.getPitch(), quaternion.getRoll());
+                                               }
+                                               finally
+                                               {
+                                                  updatingQuat.setFalse();
+                                               }
+                                            });
+
+      yawPitchRoll.getYoRoll().addListener(v ->
+                                           {
+                                              if (updatingYPR.booleanValue())
+                                                 return;
+                                              updatingQuat.setTrue();
+                                              try
+                                              {
+                                                 if (!EuclidCoreTools.epsilonEquals(quaternion.getRoll(), yawPitchRoll.getRoll(), updateThreshold))
+                                                    quaternion.setYawPitchRoll(quaternion.getYaw(), quaternion.getPitch(), yawPitchRoll.getRoll());
+                                              }
+                                              finally
+                                              {
+                                                 updatingQuat.setFalse();
+                                              }
+                                           });
+   }
+
+   private static void buildVectorListeners(YoFrameQuaternion quaternion,
+                                            YoFrameVector3D vectorA,
+                                            YoFrameVector3D vectorB,
+                                            BiConsumer<Vector3DReadOnly, Vector3DBasics> transformAToB,
+                                            BiConsumer<Vector3DReadOnly, Vector3DBasics> transformBToA)
+   {
+      MutableBoolean updatingA = new MutableBoolean(false);
+      MutableBoolean updatingB = new MutableBoolean(false);
+
+      vectorA.attachVariableChangedListener(v ->
+                                            {
+                                               if (updatingA.booleanValue())
+                                                  return;
+                                               updatingB.setTrue();
+                                               try
+                                               {
+                                                  transformAToB.accept(vectorA, vectorB);
+                                               }
+                                               finally
+                                               {
+                                                  updatingB.setFalse();
+                                               }
+                                            });
+      quaternion.getYoQs().addListener(v -> transformAToB.accept(vectorA, vectorB)); // Unidirectional update no need to check for updatingB.
+
+      double updateThreshold = 1.0e-6;
+      Vector3D intermediateVector = new Vector3D();
+
+      // Doing 1 component at a time to avoid updating the vectorA with old data.
+      vectorB.attachVariableChangedListener(v ->
+                                            {
+                                               if (updatingB.booleanValue())
+                                                  return;
+                                               updatingA.setTrue();
+                                               try
+                                               {
+                                                  transformAToB.accept(vectorA, intermediateVector);
+                                                  Axis3D axis = v == vectorB.getYoX() ? Axis3D.X : v == vectorB.getYoY() ? Axis3D.Y : Axis3D.Z;
+
+                                                  if (!EuclidCoreTools.epsilonEquals(intermediateVector.getElement(axis),
+                                                                                     vectorB.getElement(axis),
+                                                                                     updateThreshold))
+                                                  {
+                                                     intermediateVector.setElement(axis, vectorB.getElement(axis));
+                                                     transformBToA.accept(intermediateVector, vectorA);
+                                                  }
+                                               }
+                                               finally
+                                               {
+                                                  updatingA.setFalse();
+                                               }
+                                            });
    }
 
    @Override


### PR DESCRIPTION
Added a new test to check rewindability using a simple simulation example.

Two changes were necessary to get the sim to be rewindable:
- The robot frames are now updated at the beginning of the physics tick instead of being at the end. This ensures that the physics step is executed using updated frame data.
- Listeners in `SimFloatingRootJoint` that are used to maintain different representations of the joint state, were incompatible with rewindability. A simple revision on these was enough to fix the issue.