### PR TITLE
Bugfix: prevent multiple for registries with long names.

### DIFF
--- a/scs2-shared-memory/src/main/java/us/ihmc/scs2/sharedMemory/tools/SharedMemoryIOTools.java
+++ b/scs2-shared-memory/src/main/java/us/ihmc/scs2/sharedMemory/tools/SharedMemoryIOTools.java
@@ -423,6 +423,8 @@ public class SharedMemoryIOTools
       Struct nameHelperStruct = Mat5.newStruct();
       matFile.addArray("NameOverflow", nameHelperStruct);
       Map<String, MutableInt> nameOverflowCounter = new HashMap<>();
+      // Save the registry's cropped name in a map to recycle later.
+      Map<YoNamespace, String> renamedRegistryMap = new HashMap<>();
 
       yoVariableBufferStream.forEach(yoVariableBuffer ->
                                      {
@@ -438,7 +440,12 @@ public class SharedMemoryIOTools
 
                                            for (int i = 1; i < parentNamespace.size(); i++)
                                            {
-                                              String subName = parentNamespace.getSubNames().get(i);
+                                              YoNamespace ancestorNamespace = parentNamespace.subNamespace(0, i + 1);
+                                              String subName;
+                                              if (renamedRegistryMap.containsKey(ancestorNamespace))
+                                                 subName = renamedRegistryMap.get(ancestorNamespace);
+                                              else
+                                                 subName = ancestorNamespace.getShortName();
                                               Struct childStruct;
 
                                               try
@@ -449,6 +456,7 @@ public class SharedMemoryIOTools
                                               {
                                                  childStruct = Mat5.newStruct();
                                                  String registryStructName = checkAndRegisterLongName(subName, nameOverflowCounter, nameHelperStruct);
+                                                 renamedRegistryMap.put(ancestorNamespace, registryStructName);
                                                  parentStruct.set(registryStructName, childStruct);
                                               }
 

--- a/scs2-shared-memory/src/test/java/us/ihmc/scs2/sharedMemory/SharedMemoryIOToolsTest.java
+++ b/scs2-shared-memory/src/test/java/us/ihmc/scs2/sharedMemory/SharedMemoryIOToolsTest.java
@@ -132,6 +132,7 @@ public class SharedMemoryIOToolsTest
                                                                                                      MATLAB_VARNAME_MAX_LENGTH + 100));
          exportedRoot.addChild(longNameRegistry);
          new YoDouble("bloppy", longNameRegistry);
+         new YoDouble("bushy", longNameRegistry);
 
          YoSharedBuffer exportedBuffer = SharedMemoryRandomTools.nextYoSharedBuffer(random, exportedRoot);
          SharedMemoryIOTools.exportRegistry(exportedRoot, new FileOutputStream(registryFileName));


### PR DESCRIPTION
When a registry with a name that is too long, a new cropped name would be generated for every variable it holds. Fixed this by remembering when a registry gets renamed and recycling the cropped name previously generated.