### PR TITLE
:arrow_down: openjfx 17.0.8

### DIFF
--- a/scs2-session-visualizer-jfx/build.gradle.kts
+++ b/scs2-session-visualizer-jfx/build.gradle.kts
@@ -17,7 +17,7 @@ mainDependencies {
    api("us.ihmc:scs2-session-logger:source")
    api("us.ihmc:scs2-session-visualizer:source")
 
-   var javaFXVersion = "17.0.9"
+   var javaFXVersion = "17.0.8"
    api(ihmc.javaFXModule("base", javaFXVersion))
    api(ihmc.javaFXModule("controls", javaFXVersion))
    api(ihmc.javaFXModule("graphics", javaFXVersion))

--- a/scs2-session-visualizer/build.gradle.kts
+++ b/scs2-session-visualizer/build.gradle.kts
@@ -12,7 +12,7 @@ ihmc {
 mainDependencies {
    api("us.ihmc:scs2-definition:source")
 
-   var javaFXVersion = "17.0.9"
+   var javaFXVersion = "17.0.8"
    api(ihmc.javaFXModule("base", javaFXVersion)) // This is for using the property data structure. Not sure if that's the best thing to do.
 }
 


### PR DESCRIPTION
I am proposing to downgrade to 17.0.8 from 17.0.9.

17.0.9 has an incomplete artifact set. It is missing artifacts for linux-arm64.

[17.0.8](https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/17.0.8/)
[17.0.9](https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/17.0.9/)