### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/gradleCI-base.yml
+++ b/.github/workflows/gradleCI-base.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JavaFX deps
         if: ${{ inputs.setup-javafx-headless }}
         run: |
-          sudo apt-get update -y && sudo apt-get install -y libxxf86vm1 libgl1-mesa-glx
+          sudo apt-get update -y && sudo apt-get install -y libxxf86vm1 libgl1 libglx-mesa0 libgl1-mesa-dev
 
       - name: Set up Virtual Display (for Linux)
         if: ${{ inputs.setup-javafx-headless }} && ( runner.os == 'Linux' )


### PR DESCRIPTION
The reason this broke is because we use `ubuntu-latest` for the runner image and at some point it switched over to Ubuntu 24.04, which doesn't have a `libgl1-mesa-glx` package anymore.