### PR TITLE
:arrow_up: ihmc-robot-data-logger 0.36.5

### DIFF
--- a/scs2-session-logger/build.gradle.kts
+++ b/scs2-session-logger/build.gradle.kts
@@ -19,7 +19,7 @@ mainDependencies {
    api("us.ihmc:scs2-session:source")
    api("us.ihmc:scs2-simulation:source") // TODO Need to fix this, it needs the Robot.
 
-   api("us.ihmc:ihmc-robot-data-logger:0.36.4")
+   api("us.ihmc:ihmc-robot-data-logger:0.36.5")
    api("com.github.luben:zstd-jni:1.5.5-10")
    api("org.antlr:antlr4-runtime:4.13.1")
    //api("org.lz4:lz4-java:1.8.0")


### PR DESCRIPTION
This brings in an opencv upgrade as well as ZED SDK 5.1 support