### PR TITLE
Fix MagewellVideoDataReader crash on multi-stream MP4s.

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/log/MagewellVideoDataReader.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/session/log/MagewellVideoDataReader.java
@@ -33,9 +33,21 @@ public class MagewellVideoDataReader implements VideoDataReader
       return magewellScrubber.getMagewellDemuxer().getImageWidth();
    }
 
+   /** Cap on consecutive non-video packets to skip per seek (audio/timecode interleaved with video). */
+   private static final int MAX_NON_VIDEO_FRAMES_TO_SKIP = 256;
+
    public void readVideoFrame(long queryRobotTimestamp)
    {
       Frame nextFrame = magewellScrubber.readVideoFrame(queryRobotTimestamp);
+
+      // The underlying FFmpegFrameGrabber.grabFrame() returns the next packet from any stream,
+      // so a multi-stream MP4 (video + audio + timecode) may yield non-image frames here.
+      int skipped = 0;
+      while (nextFrame != null && !hasImageData(nextFrame) && skipped < MAX_NON_VIDEO_FRAMES_TO_SKIP)
+      {
+         nextFrame = magewellScrubber.getMagewellDemuxer().getNextFrame();
+         skipped++;
+      }
 
       // This is a copy that can be shown in the video view to debug timestamp issues
       {
@@ -49,6 +61,11 @@ public class MagewellVideoDataReader implements VideoDataReader
       frameData.frame = convertFrameToWritableImage(nextFrame);
    }
 
+   private static boolean hasImageData(Frame frame)
+   {
+      return frame.image != null && frame.imageWidth > 0 && frame.imageHeight > 0;
+   }
+
    /**
     * This class converts a {@link Frame} to a {@link WritableImage} in order to be displayed correctly in JavaFX.
     *
@@ -59,7 +76,7 @@ public class MagewellVideoDataReader implements VideoDataReader
    {
       Image currentImage;
 
-      if (frameToConvert == null)
+      if (frameToConvert == null || !hasImageData(frameToConvert))
       {
          return null;
       }


### PR DESCRIPTION
## Symptom

Loading a log session whose video file is a multi-stream MP4 (video + audio
and/or timecode tracks) crashed the JavaFX thread when the camera was
configured as `CAPTURE_CARD_MAGEWELL`.


Reproduced with a 4K H.265 / 60 fps MP4 from a Blackmagic HyperDeck (video +
AAC audio + tmcd timecode tracks).

## Root cause

`MagewellDemuxer.getNextFrame()` (in `ihmc-robot-data-logger`) calls
`FFmpegFrameGrabber.grabFrame()` with no stream-type filter, so it returns the
next packet from any stream. For multi-stream MP4s the packet returned right
after `seekToPTS` is often an audio or timecode frame whose `Frame.image` is
`null` and whose `imageWidth`/`imageHeight` are `0`. `JavaFXFrameConverter`
reads those dimensions directly and constructs `WritableImage(0, 0)`, which
throws.

## Fix

In `MagewellVideoDataReader.readVideoFrame`, skip non-image frames returned
by the demuxer until a real video frame arrives, capped at
`MAX_NON_VIDEO_FRAMES_TO_SKIP = 256` as a safety bound. `currentDemuxerTimestamp`
is captured after the skip loop so it reflects the displayed frame's PTS. Also
guards `convertFrameToWritableImage` against non-image frames as a defensive
measure.

## Testing

Manually verified by loading an IHMC log session whose camera entry points at
a multi-stream HEVC MP4 (60 fps, 5:49 duration). Before the patch: immediate
crash on the first frame load. After the patch: video viewer displays frames
and scrubs correctly against robot timestamps.