### PR TITLE
Setup the default layout to be one row and two columns so there is something there when opening a log

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/MainWindowController.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/MainWindowController.java
@@ -181,6 +181,12 @@ public class MainWindowController extends ObservedAnimationTimer implements Visu
             controller.setChartConfiguration(change.getValue());
          }
       });
+
+      messager.addFXTopicListener(topics.getYoChartGroupResize(), m ->
+      {
+         if (m.getKey() == null) // No window specified, apply to the main window.
+            yoChartGroupPanelController.resize(m.getValue());
+      });
    }
 
    public void setupViewport3D(Pane viewportPane)

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizer.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizer.java
@@ -41,6 +41,7 @@ import us.ihmc.scs2.session.SessionDataFilterParameters;
 import us.ihmc.scs2.session.SessionPropertiesHelper;
 import us.ihmc.scs2.sessionVisualizer.jfx.Camera3DRequest.CameraControlRequest;
 import us.ihmc.scs2.sessionVisualizer.jfx.Camera3DRequest.FocalPointRequest;
+import us.ihmc.scs2.sessionVisualizer.jfx.controllers.chart.ChartTable2D.ChartTable2DSize;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoGraphic.YoGraphicFXControllerTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.MultiSessionManager;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.ReferenceFrameManager;
@@ -488,6 +489,12 @@ public class SessionVisualizer
       public void addYoChart(String groupName, Collection<String> variableNames)
       {
          submitMessage(getTopics().getYoChartListAdd(), YoChartConfigurationDefinition.newYoVariableChartList(groupName, variableNames));
+      }
+
+      @Override
+      public void resizeYoChartGroup(int numberOfRows, int numberOfColumns)
+      {
+         submitMessage(getTopics().getYoChartGroupResize(), new Pair<>(null, new ChartTable2DSize(numberOfRows, numberOfColumns)));
       }
 
       @Override

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerControls.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerControls.java
@@ -778,6 +778,19 @@ public interface SessionVisualizerControls
    void addYoChart(String groupName, Collection<String> variableNames);
 
    /**
+    * Resizes the main chart group to the given number of rows and columns. This is equivalent to using the
+    * grid-layout picker in the GUI: any newly created cells are blank, no variable is plotted into them.
+    * <p>
+    * Existing charts that fall outside the new size are discarded, existing charts within the new size are left
+    * untouched.
+    * </p>
+    *
+    * @param numberOfRows    the new number of rows.
+    * @param numberOfColumns the new number of columns.
+    */
+   void resizeYoChartGroup(int numberOfRows, int numberOfColumns);
+
+   /**
     * Adds a variable entry to the default entry tab.
     *
     * @param variableName the name of the variable to add. The variable will be looked up using

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerMessagerAPI.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerMessagerAPI.java
@@ -13,6 +13,7 @@ import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition;
 import us.ihmc.scs2.definition.yoSlider.*;
 import us.ihmc.scs2.session.Session;
 import us.ihmc.scs2.session.SessionDataFilterParameters;
+import us.ihmc.scs2.sessionVisualizer.jfx.controllers.chart.ChartTable2D.ChartTable2DSize;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoComposite.search.SearchEngines;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.NewTerrainVisualRequest;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SecondaryWindowManager.NewWindowRequest;
@@ -67,6 +68,7 @@ public class SessionVisualizerMessagerAPI
    private static final TopicTheme Set = apiFactory.createTopicTheme("set");
    private static final TopicTheme Remove = apiFactory.createTopicTheme("remove");
    private static final TopicTheme Visible = apiFactory.createTopicTheme("visible");
+   private static final TopicTheme Resize = apiFactory.createTopicTheme("resize");
 
    public static final Topic<Boolean> DisableUserControls = APIRoot.child(User).child(Controls).topic(Disable);
    public static final Topic<SceneVideoRecordingRequest> SceneVideoRecordingRequest = APIRoot.child(Video).topic(Request);
@@ -164,6 +166,7 @@ public class SessionVisualizerMessagerAPI
       public static final Topic<Pair<Window, Boolean>> YoChartShowYAxis = APIRoot.child(YoChart).child(YAxis).topic(Show);
       public static final Topic<Pair<Window, File>> YoChartGroupSaveConfiguration = APIRoot.child(YoChart).child(Group).child(Configuration).topic(Save);
       public static final Topic<Pair<Window, File>> YoChartGroupLoadConfiguration = APIRoot.child(YoChart).child(Group).child(Configuration).topic(Load);
+      public static final Topic<Pair<Window, ChartTable2DSize>> YoChartGroupResize = APIRoot.child(YoChart).child(Group).topic(Resize);
 
       public static final Topic<ImmutablePair<String, YoChartConfigurationDefinition>> YoChartListAdd = APIRoot.child(YoChart).child(Group).topic(Add);
 

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerTopics.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerTopics.java
@@ -13,6 +13,7 @@ import us.ihmc.scs2.definition.yoGraphic.YoGraphicDefinition;
 import us.ihmc.scs2.definition.yoSlider.*;
 import us.ihmc.scs2.session.*;
 import us.ihmc.scs2.session.SessionMessagerAPI.Sensors.SensorMessage;
+import us.ihmc.scs2.sessionVisualizer.jfx.controllers.chart.ChartTable2D.ChartTable2DSize;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoComposite.search.SearchEngines;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.NewTerrainVisualRequest;
 import us.ihmc.scs2.sessionVisualizer.jfx.managers.SecondaryWindowManager.NewWindowRequest;
@@ -75,6 +76,7 @@ public class SessionVisualizerTopics
 
    private Topic<YoEntryListDefinition> yoEntryListAdd;
    private Topic<ImmutablePair<String, YoChartConfigurationDefinition>> yoChartListAdd;
+   private Topic<Pair<Window, ChartTable2DSize>> yoChartGroupResize;
 
    private Topic<File> yoMultiSliderboardSave;
    private Topic<File> yoMultiSliderboardLoad;
@@ -179,6 +181,7 @@ public class SessionVisualizerTopics
 
       yoEntryListAdd = SessionVisualizerMessagerAPI.YoEntry.YoEntryListAdd;
       yoChartListAdd = SessionVisualizerMessagerAPI.YoChart.YoChartListAdd;
+      yoChartGroupResize = SessionVisualizerMessagerAPI.YoChart.YoChartGroupResize;
 
       yoMultiSliderboardSave = SessionVisualizerMessagerAPI.YoSliderboard.YoMultiSliderboardSave;
       yoMultiSliderboardLoad = SessionVisualizerMessagerAPI.YoSliderboard.YoMultiSliderboardLoad;
@@ -426,6 +429,11 @@ public class SessionVisualizerTopics
    public Topic<Pair<Window, File>> getYoChartGroupSaveConfiguration()
    {
       return yoChartGroupSaveConfiguration;
+   }
+
+   public Topic<Pair<Window, ChartTable2DSize>> getYoChartGroupResize()
+   {
+      return yoChartGroupResize;
    }
 
    public Topic<YoEntryListDefinition> getYoEntryListAdd()

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManager.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/managers/MultiSessionManager.java
@@ -26,6 +26,7 @@ import us.ihmc.scs2.sessionVisualizer.jfx.SCSGuiConfiguration;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerIOTools;
 import us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizerTopics;
 import us.ihmc.scs2.sessionVisualizer.jfx.YoNameDisplay;
+import us.ihmc.scs2.sessionVisualizer.jfx.controllers.chart.ChartTable2D.ChartTable2DSize;
 import us.ihmc.scs2.sessionVisualizer.jfx.controllers.yoComposite.entry.YoEntryTabPaneController;
 import us.ihmc.scs2.sessionVisualizer.jfx.session.OpenSessionControlsRequest;
 import us.ihmc.scs2.sessionVisualizer.jfx.session.SessionControlsController;
@@ -264,9 +265,21 @@ public class MultiSessionManager
       SCSGuiConfiguration configuration = SCSGuiConfiguration.defaultLoader(robotName, sessionName);
 
       if (configuration == null || configuration.exists())
+      {
          loadSessionConfiguration(configuration);
-      else // No default configuration, load the one from the robot.
-         loadSessionConfiguration(SCSGuiConfiguration.defaultLoader(robotName));
+      }
+      else
+      { // No default configuration, load the one from the robot.
+         configuration = SCSGuiConfiguration.defaultLoader(robotName);
+         loadSessionConfiguration(configuration);
+      }
+
+      if (configuration == null || !configuration.hasMainYoChartGroupConfiguration())
+      {
+         // No chart layout saved for this robot/session, start with a couple of blank charts instead of an empty grid.
+         // Submitted through the messager (instead of calling the controller directly) since this method isn't always called on the FX Application Thread.
+         toolkit.getMessager().submitMessage(toolkit.getTopics().getYoChartGroupResize(), new Pair<>(null, new ChartTable2DSize(1, 2)));
+      }
    }
 
    private void loadSessionConfiguration(SCSGuiConfiguration configuration)

--- a/scs2-simulation-construction-set/src/main/java/us/ihmc/scs2/SimulationConstructionSet2.java
+++ b/scs2-simulation-construction-set/src/main/java/us/ihmc/scs2/SimulationConstructionSet2.java
@@ -1214,6 +1214,13 @@ public class SimulationConstructionSet2 implements YoVariableHolder, SimulationS
 
    /** {@inheritDoc} */
    @Override
+   public void resizeYoChartGroup(int numberOfRows, int numberOfColumns)
+   {
+      executeOrScheduleVisualizerTask(() -> visualizerControls.resizeYoChartGroup(numberOfRows, numberOfColumns));
+   }
+
+   /** {@inheritDoc} */
+   @Override
    public void addYoEntry(String groupName, Collection<String> variableNames)
    {
       executeOrScheduleVisualizerTask(() -> visualizerControls.addYoEntry(groupName, variableNames));


### PR DESCRIPTION
This makes the default SCS2 app when opening a log to contain one row, and two columns of empty charts. This way the user doesn't have to open any charts when playing a log. Saves a click, I liked it