### PR TITLE
Reset runTickCounter in LogSession/RemoteSession so runMaxDuration caps every run

### DIFF
--- a/scs2-session-logger/src/main/java/us/ihmc/scs2/session/log/LogSession.java
+++ b/scs2-session-logger/src/main/java/us/ihmc/scs2/session/log/LogSession.java
@@ -212,6 +212,7 @@ public class LogSession extends Session
          // Without that, scrubbing through a chart and then resuming log reading will start from an arbitrary position in the log file (corresponding to where we last stop reading the log file).
          logDataReader.seek(logDataReader.getCurrentLogPosition());
          nextRunBufferRecordTickCounter = 0;
+         runTickCounter = 0L;
          firstRunTick = false;
       }
       else if (nextRunBufferRecordTickCounter <= 0)

--- a/scs2-session-logger/src/main/java/us/ihmc/scs2/session/remote/RemoteSession.java
+++ b/scs2-session-logger/src/main/java/us/ihmc/scs2/session/remote/RemoteSession.java
@@ -201,6 +201,7 @@ public class RemoteSession extends Session
          sharedBuffer.setInPoint(sharedBuffer.getProperties().getCurrentIndex());
          sharedBuffer.processLinkedPushRequests(false);
          nextRunBufferRecordTickCounter = 0;
+         runTickCounter = 0L;
          firstRunTick = false;
       }
       else if (nextRunBufferRecordTickCounter <= 0)

--- a/scs2-session/src/main/java/us/ihmc/scs2/session/Session.java
+++ b/scs2-session/src/main/java/us/ihmc/scs2/session/Session.java
@@ -317,7 +317,7 @@ public abstract class Session
    /**
     * Used to keep track of how long the session has been running.
     */
-   private long runTickCounter = 0L;
+   protected long runTickCounter = 0L;
 
    // State listener to publish internal to outside world
    /**


### PR DESCRIPTION
## Summary
- Second "Start running" in a log/remote session pauses after one tick even when a run-max-duration is configured.
- `Session.runTick()` caps duration with `runTickCounter * sessionDTNanoseconds >= runMaxDuration`. The base `initializeRunTick` zeros `runTickCounter` on each run, but `LogSession` and `RemoteSession` override that method and never reset it, so leftover ticks from the previous run trip the cap immediately.
- Zero `runTickCounter` in both overrides (matching the base) and widen the field from `private` to `protected` on `Session`, same visibility as the neighboring `firstRunTick` / `nextRunBufferRecordTickCounter` fields.

Came from Persona's SCS2 fork replay onto 17-0.33.4. Replaces #273, which was opened from a personal fork before write access to this repo.

## Test plan
- [x] Cherry-picked onto current `origin/develop`; compile of the touched modules (`:scs2-session:compileJava`, `:scs2-session-logger:compileJava`) was green.
- [ ] No existing unit tests cover `initializeRunTick` / `runMaxDuration` on log or remote sessions.
- [ ] Manual: start a log session, run until max duration pauses, press Start running again — it should run for the full configured duration, not one tick.


Made with [Cursor](https://cursor.com)