### PR TITLE
Disable driver VSync in installDist and warn if still enabled

### DIFF
--- a/scs2-session-visualizer-jfx/build.gradle.kts
+++ b/scs2-session-visualizer-jfx/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.tasks.application.CreateStartScripts
 
 plugins {
    id("us.ihmc.ihmc-build")
@@ -90,6 +91,24 @@ tasks.getByPath("installDist").dependsOn("compositeJar")
 app.entrypoint(sessionVisualizerExecutableName, "us.ihmc.scs2.sessionVisualizer.jfx.SessionVisualizer", listOf("-Djdk.gtk.version=2", "-Dprism.vsync=false"))
 app.entrypoint(mcapRepackAppExecutableName, "us.ihmc.scs2.sessionVisualizer.jfx.session.mcap.MCAPRepackApplication", listOf("-Djdk.gtk.version=2", "-Dprism.vsync=false"))
 
+// Post-process the generated unix launch scripts (installDist, installDistLinux, and the .deb which
+// copies from the install output) so every distribution disables driver VSync itself, without the
+// user needing to set __GL_SYNC_TO_VBLANK. The contains() guard keeps this idempotent.
+tasks.withType<CreateStartScripts>().configureEach {
+   doLast {
+      val script = unixScript
+      val text = script.readText()
+      if (!text.contains("__GL_SYNC_TO_VBLANK")) {
+         script.writeText(
+            text.replaceFirst(
+               "#!/bin/sh",
+               "#!/bin/sh\n# Workaround JDK-8291958: disable driver VSync to fix multi-window playback stutter.\nexport __GL_SYNC_TO_VBLANK=0"
+            )
+         )
+      }
+   }
+}
+
 /**
  * This task is used to compile the project and filter out any dependency not required for Linux.
  */
@@ -133,9 +152,6 @@ tasks.register("buildDebianPackage") {
       fileTree("$sourceFolder/bin").matching {
          exclude(sessionVisualizerExecutableName, mcapRepackAppExecutableName)
       }.forEach(File::delete)
-
-      addVSyncLinuxHackForJavaFXApp(sourceFolder, sessionVisualizerExecutableName)
-      addVSyncLinuxHackForJavaFXApp(sourceFolder, mcapRepackAppExecutableName)
 
       File("$baseFolder/DEBIAN").mkdirs()
       println("Created directory $baseFolder/DEBIAN/: ${File("${baseFolder}/DEBIAN").exists()}")
@@ -193,23 +209,6 @@ tasks.register("buildDebianPackage") {
          ihmc.exec(ProcessBuilder("dpkg", "--build", "scs2-${ihmc.version}").directory(File(debianFolder)))
       }
    }
-}
-
-fun addVSyncLinuxHackForJavaFXApp(sourceFolder: String, javafxappname: String)
-{
-   val launchScriptFile = File("$sourceFolder/bin/$javafxappname")
-   var originalScript = launchScriptFile.readText()
-   originalScript = originalScript.replaceFirst(
-         "#!/bin/sh", """
-         #!/bin/bash
-         # This is a workaround for a bug in JavaFX 17.0.1, disabling vsync to improve framerate with multiple windows.
-         export __GL_SYNC_TO_VBLANK=0
-
-      """.trimIndent()
-   )
-
-   launchScriptFile.delete()
-   launchScriptFile.writeText(originalScript)
 }
 
 // Stable upgrade UUID for the Windows MSI. Must never change across releases:

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizer.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizer.java
@@ -140,6 +140,10 @@ public class SessionVisualizer
       // This may be related to the bug reported when using GTK3: https://github.com/javafxports/openjdk-jfx/pull/446, might be fixed in later version.
       initializeStageWithPrimaryScreen();
 
+      // Warn (once, when the main window comes up) if VSync is left enabled on Linux, which is typically the case
+      // when launching from an IDE instead of the SCS2SessionVisualizer script that sets __GL_SYNC_TO_VBLANK=0.
+      JavaFXApplicationCreator.showVSyncWarningDialogIfNeeded();
+
       if (initialSession != null)
       {
          Runnable sessionLoadedCallback = () -> sessionVisualizerControls.visualizerReadyLatch.countDown();

--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/JavaFXApplicationCreator.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/tools/JavaFXApplicationCreator.java
@@ -7,6 +7,11 @@ import java.util.concurrent.CountDownLatch;
 import org.apache.commons.lang3.SystemUtils;
 
 import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.control.Alert;
+import javafx.scene.control.Alert.AlertType;
+import javafx.scene.control.ButtonType;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 /**
@@ -58,29 +63,72 @@ public class JavaFXApplicationCreator extends Application
             System.setProperty(prism_vsync_name, "false");
          }
 
-         int glSyncToVBlankIntValue;
-         String glSyncToVBlankProperty = System.getenv(gl_vsync_name);
-         if (glSyncToVBlankProperty == null)
-         {
-            glSyncToVBlankIntValue = -1;
-         }
-         else
-         {
-            try
-            {
-               glSyncToVBlankIntValue = Integer.parseInt(glSyncToVBlankProperty);
-            }
-            catch (NumberFormatException e)
-            {
-               e.printStackTrace();
-               glSyncToVBlankIntValue = -1;
-            }
-         }
-
-         if (glSyncToVBlankIntValue != 0)
+         if (isVSyncMisconfiguredOnLinux())
             System.err.println("%s: JavaFX performance warning: disable VSync for better multi-window performance, run with environment variable: %s=0".formatted(JavaFXApplicationCreator.class.getSimpleName(),
                                                                                                                                                                   gl_vsync_name));
       }
+   }
+
+   /**
+    * Checks whether VSync is left enabled on Linux, i.e. the {@code __GL_SYNC_TO_VBLANK} environment
+    * variable is not set to {@code 0}.
+    * <p>
+    * A {@code null}, unparseable, or non-zero value all count as misconfigured. See
+    * {@link #verifyVSyncDisabledUbuntu()} for the underlying issue.
+    * </p>
+    *
+    * @return {@code true} when running on Linux and {@code __GL_SYNC_TO_VBLANK} is not {@code 0}.
+    */
+   public static boolean isVSyncMisconfiguredOnLinux()
+   {
+      if (!SystemUtils.IS_OS_LINUX)
+         return false;
+
+      String glSyncToVBlankProperty = System.getenv("__GL_SYNC_TO_VBLANK");
+      if (glSyncToVBlankProperty == null)
+         return true;
+
+      try
+      {
+         return Integer.parseInt(glSyncToVBlankProperty) != 0;
+      }
+      catch (NumberFormatException e)
+      {
+         e.printStackTrace();
+         return true;
+      }
+   }
+
+   /**
+    * If VSync is misconfigured on Linux (see {@link #isVSyncMisconfiguredOnLinux()}), pops up a
+    * non-blocking warning dialog explaining that multi-window playback may stutter and how to fix it.
+    * <p>
+    * This complements the console warning emitted by {@link #verifyVSyncDisabledUbuntu()}, which runs
+    * before the JavaFX toolkit is up and thus cannot show a dialog. This method is safe to call from
+    * any thread; the dialog is shown on the JavaFX Application Thread.
+    * </p>
+    */
+   public static void showVSyncWarningDialogIfNeeded()
+   {
+      if (!isVSyncMisconfiguredOnLinux())
+         return;
+
+      Platform.runLater(() ->
+      {
+         Alert alert = new Alert(AlertType.WARNING, "", ButtonType.OK);
+         alert.initModality(Modality.APPLICATION_MODAL);
+         alert.setTitle("Performance Warning");
+         alert.setHeaderText("VSync is not disabled (multi-window playback may stutter)");
+         alert.setContentText("""
+                              The environment variable __GL_SYNC_TO_VBLANK=0 is not set, so multi-window chart playback will stutter.
+
+                              Recommended fix: launch SCS2 via the SCS2SessionVisualizer script, which sets it automatically:
+                                - when running from source: build/install/.../bin/SCS2SessionVisualizer
+                                - or install and run the packaged .deb
+
+                              If running from an IDE, add the environment variable __GL_SYNC_TO_VBLANK=0 to the run configuration.""");
+         alert.show();
+      });
    }
 
    private void setStartUpTest(JavaFXApplicationCreator startUpTest)


### PR DESCRIPTION
## Summary
- Multi-window SCS2 playback stutters on Linux when NVIDIA driver VSync is left on (`__GL_SYNC_TO_VBLANK` unset). JDK/JavaFX cannot disable that from inside the process (JDK-8291958).
- The `.deb` packager already injected `export __GL_SYNC_TO_VBLANK=0` into start scripts, but `installDist` / `installDistLinux` did not, so source and IDE launches still stutter. Console-only warnings are easy to miss.
- Post-process every `CreateStartScripts` unix launcher so `installDist` (and the `.deb`, which copies those scripts) exports `__GL_SYNC_TO_VBLANK=0`. On Linux, if an IDE launch still left VSync on, show a one-shot warning dialog when the main window appears.

Came from Persona's SCS2 fork replay onto 17-0.33.4. Replaces #274, which was opened from a personal fork before write access to this repo.

## Test plan
- [x] Cherry-picked onto current `origin/develop`.
- [ ] No unit tests for start-script generation or the VSync dialog.
- [ ] `installDist` / generated `bin/SCS2SessionVisualizer` contains `export __GL_SYNC_TO_VBLANK=0`.
- [ ] Launch without that env var on Linux: warning dialog appears; with `=0`, no dialog.


Made with [Cursor](https://cursor.com)