### PR TITLE
Fix addYoChart(String, String) named-group overload calling addYoEntry instead of addYoChart

### DIFF
--- a/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerControls.java
+++ b/scs2-session-visualizer-jfx/src/main/java/us/ihmc/scs2/sessionVisualizer/jfx/SessionVisualizerControls.java
@@ -764,7 +764,7 @@ public interface SessionVisualizerControls
     */
    default void addYoChart(String groupName, String variableName)
    {
-      addYoEntry(groupName, Collections.singletonList(variableName));
+      addYoChart(groupName, Collections.singletonList(variableName));
    }
 
    /**


### PR DESCRIPTION
## Summary
- `SessionVisualizerControls.addYoChart(String groupName, String variableName)` is documented as adding a single-variable chart in a named group, but it called `addYoEntry(...)`. Callers got a side-pane entry instead of a chart.
- Copy-paste in the default method: the no-group single-variable overload correctly delegates to `addYoChart(Collection)`, and the named-group collection overload is `addYoChart(String, Collection)`, but this overload routed through `addYoEntry`.
- Change the default method to `addYoChart(groupName, Collections.singletonList(variableName))`.

Came from Persona's SCS2 fork replay onto 17-0.33.4.

## Test plan
- [x] Cherry-picked onto current `origin/develop`; parent is `origin/develop`. `:scs2-session-visualizer-jfx:compileJava` was green.
- [ ] No existing unit tests cover the `addYoChart` default overloads.
- [ ] Manual: `addYoChart("group", "variable")` creates a chart in that group, not a side-pane entry.


Made with [Cursor](https://cursor.com)